### PR TITLE
feat: Add auto-scroll functionality and enhance reader utilities

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/reader/appbars/ExhUtils.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/appbars/ExhUtils.kt
@@ -1,0 +1,233 @@
+package eu.kanade.presentation.reader.appbars
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.KeyboardArrowDown
+import androidx.compose.material.icons.outlined.KeyboardArrowUp
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import tachiyomi.i18n.tail.TLMR
+import tachiyomi.presentation.core.i18n.stringResource
+
+@Composable
+fun ExhUtils(
+    isVisible: Boolean,
+    onSetExhUtilsVisibility: (Boolean) -> Unit,
+    backgroundColor: Color,
+    isAutoScroll: Boolean,
+    isAutoScrollEnabled: Boolean,
+    onToggleAutoscroll: (Boolean) -> Unit,
+    autoScrollFrequency: String,
+    onSetAutoScrollFrequency: (String) -> Unit,
+    onClickAutoScrollHelp: () -> Unit,
+    onClickRetryAll: () -> Unit,
+    onClickRetryAllHelp: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier
+            .fillMaxWidth()
+            .background(backgroundColor),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        AnimatedVisibility(visible = isVisible) {
+            Column {
+                Row(
+                    Modifier
+                        .fillMaxWidth(0.9f)
+                        .height(IntrinsicSize.Min),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Row(
+                        Modifier
+                            .fillMaxWidth(0.5f)
+                            .fillMaxHeight()
+                            .padding(5.dp)
+                            .clickable(enabled = isAutoScrollEnabled) { onToggleAutoscroll(!isAutoScroll) },
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Column(
+                            Modifier.weight(3f),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                        ) {
+                            Text(
+                                text = stringResource(TLMR.strings.eh_autoscroll),
+                                color = MaterialTheme.colorScheme.onSurface,
+                                fontSize = 13.sp,
+                                fontFamily = FontFamily.SansSerif,
+                                style = MaterialTheme.typography.labelLarge,
+                                modifier = Modifier.fillMaxWidth(0.75f),
+                                textAlign = TextAlign.Center,
+                            )
+                        }
+                        Column(
+                            Modifier.weight(1f),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                        ) {
+                            Switch(
+                                checked = isAutoScroll,
+                                onCheckedChange = null,
+                                enabled = isAutoScrollEnabled,
+                            )
+                        }
+                    }
+                    Row(
+                        Modifier.fillMaxWidth(0.9f).padding(5.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Column(
+                            Modifier.weight(3f),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                        ) {
+                            var autoScrollFrequencyState by remember {
+                                mutableStateOf(autoScrollFrequency)
+                            }
+                            TextField(
+                                value = autoScrollFrequencyState,
+                                onValueChange = {
+                                    autoScrollFrequencyState = it
+                                    onSetAutoScrollFrequency(it)
+                                },
+                                isError = !isAutoScrollEnabled,
+                                singleLine = true,
+                                colors = TextFieldDefaults.colors(
+                                    focusedContainerColor = Color.Transparent,
+                                    unfocusedContainerColor = Color.Transparent,
+                                    focusedTextColor = MaterialTheme.colorScheme.onSurface,
+                                    unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
+                                ),
+                                modifier = Modifier.fillMaxWidth(0.75f),
+                                keyboardOptions = KeyboardOptions(
+                                    keyboardType = KeyboardType.Decimal,
+                                ),
+                            )
+                            AnimatedVisibility(!isAutoScrollEnabled) {
+                                Text(
+                                    text = stringResource(TLMR.strings.eh_autoscroll_freq_invalid),
+                                    color = MaterialTheme.colorScheme.error,
+                                    style = MaterialTheme.typography.labelSmall,
+                                )
+                            }
+                        }
+                        TextButton(
+                            onClick = onClickAutoScrollHelp,
+                            modifier = Modifier.weight(1f),
+                        ) {
+                            Text(
+                                text = "?",
+                                color = MaterialTheme.colorScheme.onSurface,
+                                fontSize = 15.sp,
+                                fontWeight = FontWeight.Bold,
+                            )
+                        }
+                    }
+                }
+                Row(
+                    Modifier.fillMaxWidth(0.9f),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Row(
+                        Modifier.fillMaxWidth(0.5f).padding(5.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        TextButton(
+                            onClick = onClickRetryAll,
+                            modifier = Modifier.weight(3f),
+                        ) {
+                            Text(
+                                text = stringResource(TLMR.strings.eh_retry_all),
+                                color = MaterialTheme.colorScheme.onSurface,
+                                fontSize = 13.sp,
+                                fontFamily = FontFamily.SansSerif,
+                            )
+                        }
+                        TextButton(
+                            onClick = onClickRetryAllHelp,
+                            modifier = Modifier.weight(1f),
+                        ) {
+                            Text(
+                                text = "?",
+                                color = MaterialTheme.colorScheme.onSurface,
+                                fontSize = 15.sp,
+                                fontWeight = FontWeight.Bold,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        IconButton(
+            onClick = { onSetExhUtilsVisibility(!isVisible) },
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Icon(
+                imageVector = if (isVisible) {
+                    Icons.Outlined.KeyboardArrowUp
+                } else {
+                    Icons.Outlined.KeyboardArrowDown
+                },
+                contentDescription = null,
+                // KMK -->
+                tint = MaterialTheme.colorScheme.primary,
+                // KMK <--
+            )
+        }
+    }
+}
+
+@Composable
+@PreviewLightDark
+private fun ExhUtilsPreview() {
+    Surface {
+        ExhUtils(
+            isVisible = true,
+            onSetExhUtilsVisibility = {},
+            backgroundColor = Color.Black,
+            isAutoScroll = true,
+            isAutoScrollEnabled = true,
+            onToggleAutoscroll = {},
+            autoScrollFrequency = "3.0",
+            onSetAutoScrollFrequency = {},
+            onClickAutoScrollHelp = {},
+            onClickRetryAll = {},
+            onClickRetryAllHelp = {},
+        )
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/reader/appbars/ReaderAppBars.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/appbars/ReaderAppBars.kt
@@ -67,6 +67,16 @@ fun ReaderAppBars(
     onClickCropBorder: () -> Unit,
     onClickSettings: () -> Unit,
     // SY -->
+    isExhToolsVisible: Boolean,
+    onSetExhUtilsVisibility: (Boolean) -> Unit,
+    isAutoScroll: Boolean,
+    isAutoScrollEnabled: Boolean,
+    onToggleAutoscroll: (Boolean) -> Unit,
+    autoScrollFrequency: String,
+    onSetAutoScrollFrequency: (String) -> Unit,
+    onClickAutoScrollHelp: () -> Unit,
+    onClickRetryAll: () -> Unit,
+    onClickRetryAllHelp: () -> Unit,
     currentPageText: String,
     enabledButtons: Set<String>,
     dualPageSplitEnabled: Boolean,
@@ -101,63 +111,80 @@ fun ReaderAppBars(
                 animationSpec = animationSpec,
             ),
         ) {
-            AppBar(
-                modifier = modifierWithInsetsPadding
-                    .clickable(onClick = onClickTopAppBar),
-                backgroundColor = backgroundColor,
-                title = mangaTitle,
-                subtitle = chapterTitle,
-                navigateUp = navigateUp,
-                actions = {
-                    AppBarActions(
-                        actions = persistentListOf<AppBar.AppBarAction>().builder()
-                            .apply {
-                                add(
-                                    AppBar.Action(
-                                        title = stringResource(
-                                            if (bookmarked) {
-                                                MR.strings.action_remove_bookmark
+            // SY -->
+            Column(modifier = modifierWithInsetsPadding.clickable(onClick = onClickTopAppBar)) {
+                AppBar(
+                    modifier = Modifier,
+                    backgroundColor = backgroundColor,
+                    title = mangaTitle,
+                    subtitle = chapterTitle,
+                    navigateUp = navigateUp,
+                    actions = {
+                        AppBarActions(
+                            actions = persistentListOf<AppBar.AppBarAction>().builder()
+                                .apply {
+                                    add(
+                                        AppBar.Action(
+                                            title = stringResource(
+                                                if (bookmarked) {
+                                                    MR.strings.action_remove_bookmark
+                                                } else {
+                                                    MR.strings.action_bookmark
+                                                },
+                                            ),
+                                            icon = if (bookmarked) {
+                                                Icons.Outlined.Bookmark
                                             } else {
-                                                MR.strings.action_bookmark
+                                                Icons.Outlined.BookmarkBorder
                                             },
-                                        ),
-                                        icon = if (bookmarked) {
-                                            Icons.Outlined.Bookmark
-                                        } else {
-                                            Icons.Outlined.BookmarkBorder
-                                        },
-                                        onClick = onToggleBookmarked,
-                                    ),
-                                )
-                                onOpenInWebView?.let {
-                                    add(
-                                        AppBar.OverflowAction(
-                                            title = stringResource(MR.strings.action_open_in_web_view),
-                                            onClick = it,
+                                            onClick = onToggleBookmarked,
                                         ),
                                     )
+                                    onOpenInWebView?.let {
+                                        add(
+                                            AppBar.OverflowAction(
+                                                title = stringResource(MR.strings.action_open_in_web_view),
+                                                onClick = it,
+                                            ),
+                                        )
+                                    }
+                                    onOpenInBrowser?.let {
+                                        add(
+                                            AppBar.OverflowAction(
+                                                title = stringResource(MR.strings.action_open_in_browser),
+                                                onClick = it,
+                                            ),
+                                        )
+                                    }
+                                    onShare?.let {
+                                        add(
+                                            AppBar.OverflowAction(
+                                                title = stringResource(MR.strings.action_share),
+                                                onClick = it,
+                                            ),
+                                        )
+                                    }
                                 }
-                                onOpenInBrowser?.let {
-                                    add(
-                                        AppBar.OverflowAction(
-                                            title = stringResource(MR.strings.action_open_in_browser),
-                                            onClick = it,
-                                        ),
-                                    )
-                                }
-                                onShare?.let {
-                                    add(
-                                        AppBar.OverflowAction(
-                                            title = stringResource(MR.strings.action_share),
-                                            onClick = it,
-                                        ),
-                                    )
-                                }
-                            }
-                            .build(),
-                    )
-                },
-            )
+                                .build(),
+                        )
+                    },
+                )
+                // SY -->
+                ExhUtils(
+                    isVisible = isExhToolsVisible,
+                    onSetExhUtilsVisibility = onSetExhUtilsVisibility,
+                    backgroundColor = backgroundColor,
+                    isAutoScroll = isAutoScroll,
+                    isAutoScrollEnabled = isAutoScrollEnabled,
+                    onToggleAutoscroll = onToggleAutoscroll,
+                    autoScrollFrequency = autoScrollFrequency,
+                    onSetAutoScrollFrequency = onSetAutoScrollFrequency,
+                    onClickAutoScrollHelp = onClickAutoScrollHelp,
+                    onClickRetryAll = onClickRetryAll,
+                    onClickRetryAllHelp = onClickRetryAllHelp,
+                )
+                // SY <--
+            } // SY <--
         }
 
         Spacer(modifier = Modifier.weight(1f))

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/anime/util/AnimeExtensionLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/anime/util/AnimeExtensionLoader.kt
@@ -22,8 +22,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
 import logcat.LogPriority
-import mihon.domain.extensionrepo.anime.interactor.CreateAnimeExtensionRepo.Companion.KEIYOUSHI_REPO_SIGNATURE
-import mihon.domain.extensionrepo.anime.interactor.CreateAnimeExtensionRepo.Companion.OFFICIAL_REPO_SIGNATURE
+import mihon.domain.extensionrepo.anime.interactor.CreateAnimeExtensionRepo.Companion.ANIMETAIL_SIGNATURE
 import mihon.domain.extensionrepo.anime.interactor.GetAnimeExtensionRepo
 import mihon.domain.extensionrepo.model.ExtensionRepo
 import tachiyomi.core.common.util.system.logcat
@@ -409,11 +408,7 @@ internal object AnimeExtensionLoader {
     }
 
     private fun isOfficiallySigned(signatures: List<String>): Boolean {
-        return signatures.all { it == OFFICIAL_REPO_SIGNATURE }
-    }
-
-    private fun isKeiyoushiSigned(signatures: List<String>): Boolean {
-        return signatures.all { it == KEIYOUSHI_REPO_SIGNATURE }
+        return signatures.all { it == ANIMETAIL_SIGNATURE }
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/manga/util/MangaExtensionLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/manga/util/MangaExtensionLoader.kt
@@ -22,8 +22,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
 import logcat.LogPriority
-import mihon.domain.extensionrepo.anime.interactor.CreateAnimeExtensionRepo.Companion.KEIYOUSHI_REPO_SIGNATURE
-import mihon.domain.extensionrepo.anime.interactor.CreateAnimeExtensionRepo.Companion.OFFICIAL_REPO_SIGNATURE
+import mihon.domain.extensionrepo.anime.interactor.CreateAnimeExtensionRepo.Companion.KEIYOUSHI_SIGNATURE
 import mihon.domain.extensionrepo.manga.interactor.GetMangaExtensionRepo
 import mihon.domain.extensionrepo.model.ExtensionRepo
 import tachiyomi.core.common.util.system.logcat
@@ -414,12 +413,8 @@ internal object MangaExtensionLoader {
         return MangaLoadResult.Success(extension)
     }
 
-    private fun isOfficiallySigned(signatures: List<String>): Boolean {
-        return signatures.all { it == OFFICIAL_REPO_SIGNATURE }
-    }
-
     private fun isKeiyoushiSigned(signatures: List<String>): Boolean {
-        return signatures.all { it == KEIYOUSHI_REPO_SIGNATURE }
+        return signatures.all { it == KEIYOUSHI_SIGNATURE }
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/home/HomeScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/home/HomeScreen.kt
@@ -77,7 +77,7 @@ object HomeScreen : Screen() {
     private const val TAB_FADE_DURATION = 200
     private const val TAB_NAVIGATOR_KEY = "HomeTabs"
 
-    private val uiPreferences: UiPreferences by injectLazy()
+    val uiPreferences: UiPreferences by injectLazy()
     private val defaultTab = uiPreferences.startScreen().get().tab
     private val moreTab = uiPreferences.navStyle().get().moreTab
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoader.kt
@@ -131,6 +131,7 @@ internal class HttpPageLoader(
         if (page.status == Page.State.ERROR) {
             page.status = Page.State.QUEUE
         }
+
         queue.offer(PriorityPage(page, 2))
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -143,6 +143,14 @@ class ReaderPreferences(
 
     fun showNavigationOverlayOnStart() = preferenceStore.getBoolean("reader_navigation_overlay_on_start", false)
 
+    // sy -->
+    fun readerInstantRetry() = preferenceStore.getBoolean("eh_reader_instant_retry", true)
+
+    fun autoscrollInterval() = preferenceStore.getFloat("eh_util_autoscroll_interval", 3f)
+
+    fun smoothAutoScroll() = preferenceStore.getBoolean("smooth_auto_scroll", true)
+    // sy <--
+
     // J2K -->
     fun preloadSize() = preferenceStore.getInt("reader_preload_size", PRELOAD_SIZE_MIN)
     // J2K <--

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -6,6 +6,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.view.animation.LinearInterpolator
 import androidx.core.app.ActivityCompat
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
@@ -27,6 +28,7 @@ import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.time.Duration
 
 /**
  * Implementation of a [Viewer] to display pages with a [RecyclerView].
@@ -293,12 +295,24 @@ class WebtoonViewer(val activity: ReaderActivity, val isContinuous: Boolean = tr
     /**
      * Scrolls down by [scrollDistance].
      */
-    private fun scrollDown() {
+    fun scrollDown() {
         if (config.usePageTransitions) {
             recycler.smoothScrollBy(0, scrollDistance)
         } else {
             recycler.scrollBy(0, scrollDistance)
         }
+    }
+
+    /**
+     * Scrolls one screen over a period of time
+     */
+    fun linearScroll(duration: Duration) {
+        recycler.smoothScrollBy(
+            0,
+            activity.resources.displayMetrics.heightPixels,
+            LinearInterpolator(),
+            duration.inWholeMilliseconds.toInt(),
+        )
     }
 
     /**

--- a/i18n-tail/src/commonMain/moko-resources/base/plurals.xml
+++ b/i18n-tail/src/commonMain/moko-resources/base/plurals.xml
@@ -1,3 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <plurals name="eh_retry_toast">
+        <item quantity="zero">Retrying 0 failed pages…</item>
+        <item quantity="one">Retrying %1$d failed page…</item>
+        <item quantity="other">Retrying %1$d failed pages…</item>
+    </plurals>
 </resources>

--- a/i18n-tail/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-tail/src/commonMain/moko-resources/base/strings.xml
@@ -204,4 +204,22 @@
     <string name="cast_not_connected">Cast not connected</string>
     <string name="cast_video_added_to_queue">Video added to queue</string>
     <string name="cast_error_loading">Error loading video from Cast</string>
+
+    <!-- Auto scroll -->
+    <string name="eh_autoscroll">Autoscroll</string>
+    <string name="eh_retry_all">Retry all</string>
+    <string name="eh_boost_page">Boost page</string>
+    <string name="eh_autoscroll_help">Autoscroll help</string>
+    <string name="eh_autoscroll_help_message">Automatically scroll to the next page in the specified interval. Interval is specified in seconds.</string>
+    <string name="eh_autoscroll_freq_invalid">Invalid frequency</string>
+    <string name="eh_retry_all_help">Retry all help</string>
+    <string name="eh_retry_all_help_message">Re-add all failed pages to the download queue.</string>
+    <string name="eh_boost_page_help">Boost page help</string>
+    <string name="eh_boost_page_help_message">Normally the downloader can only download a specific amount of pages at the same time. This means you can be waiting for a page to download but the downloader will not start downloading the page until it has a free download slot. Pressing \'Boost page\' will force the downloader to begin downloading the current page, regardless of whether or not there is an available slot.</string>
+    <string name="eh_boost_page_invalid">This page cannot be boosted (invalid page)!</string>
+    <string name="eh_boost_page_errored">Page failed to load, press the retry button instead!</string>
+    <string name="eh_boost_page_downloading">This page is already downloading!</string>
+    <string name="eh_boost_page_downloaded">This page has already been downloaded!</string>
+    <string name="eh_boost_boosted">Boosted current page!</string>
+    <string name="eh_boost_invalid_loader">This page cannot be boosted (invalid page loader)!</string>
 </resources>


### PR DESCRIPTION
This pull request introduces new functionality and refactors existing code to support enhanced reader utilities in the app. The most significant changes include the addition of the `ExhUtils` composable, updates to the `ReaderAppBars` to integrate the new utilities, and modifications to the `AnimeExtensionLoader` and `MangaExtensionLoader` to update signature checks.

### Enhancements to Reader Utilities:

* [`app/src/main/java/eu/kanade/presentation/reader/appbars/ExhUtils.kt`](diffhunk://#diff-3b910f12f9d9a4d27332de94f4a5d77535832fbe601cce96b427cd4d1f8f3ddfR1-R233): Added a new `ExhUtils` composable for enhanced reader utilities, including auto-scroll and retry functionality.
* [`app/src/main/java/eu/kanade/presentation/reader/appbars/ReaderAppBars.kt`](diffhunk://#diff-e94e4218b946a17e52846157e3b79c0fcb93404b44d84938457fc6da3a5e2052R70-R79): Integrated `ExhUtils` into the `ReaderAppBars` composable, adding parameters and updating the layout to include the new utilities. [[1]](diffhunk://#diff-e94e4218b946a17e52846157e3b79c0fcb93404b44d84938457fc6da3a5e2052R70-R79) [[2]](diffhunk://#diff-e94e4218b946a17e52846157e3b79c0fcb93404b44d84938457fc6da3a5e2052R114-R117) [[3]](diffhunk://#diff-e94e4218b946a17e52846157e3b79c0fcb93404b44d84938457fc6da3a5e2052R172-R187)

### Additional Updates:

* [`app/src/main/java/eu/kanade/tachiyomi/ui/home/HomeScreen.kt`](diffhunk://#diff-eee8cda08bf8d950466a23c7ea82cfdcef81b70c77139ddbfdf0b61bb8d9d45aL80-R80): Made `uiPreferences` public for broader accessibility.
* [`app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt`](diffhunk://#diff-8838a16c33623595854e150da6121e7de3bbd25566e34bca42dddadade8dfefcR30): Added imports and updated the `ReaderActivity` to integrate the new `ExhUtils` functionality. [[1]](diffhunk://#diff-8838a16c33623595854e150da6121e7de3bbd25566e34bca42dddadade8dfefcR30) [[2]](diffhunk://#diff-8838a16c33623595854e150da6121e7de3bbd25566e34bca42dddadade8dfefcR43-R45) [[3]](diffhunk://#diff-8838a16c33623595854e150da6121e7de3bbd25566e34bca42dddadade8dfefcR72) [[4]](diffhunk://#diff-8838a16c33623595854e150da6121e7de3bbd25566e34bca42dddadade8dfefcR89) [[5]](diffhunk://#diff-8838a16c33623595854e150da6121e7de3bbd25566e34bca42dddadade8dfefcR99-R112) [[6]](diffhunk://#diff-8838a16c33623595854e150da6121e7de3bbd25566e34bca42dddadade8dfefcR125) [[7]](diffhunk://#diff-8838a16c33623595854e150da6121e7de3bbd25566e34bca42dddadade8dfefcR488-R497)