### PR TITLE
fix(prefs): Don't format mpv preferences

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/PreferenceItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/PreferenceItem.kt
@@ -183,6 +183,7 @@ internal fun PreferenceItem(
                     },
                     singleLine = false,
                     canBeBlank = item.canBeBlank,
+                    formatSubtitle = false,
                 )
             }
             is Preference.PreferenceItem.EditTextInfoPreference -> {

--- a/app/src/main/java/eu/kanade/presentation/more/settings/widget/EditTextPreferenceWidget.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/widget/EditTextPreferenceWidget.kt
@@ -37,12 +37,13 @@ fun EditTextPreferenceWidget(
     onConfirm: suspend (String) -> Boolean,
     singleLine: Boolean = true,
     canBeBlank: Boolean = false,
+    formatSubtitle: Boolean = true,
 ) {
     var isDialogShown by remember { mutableStateOf(false) }
 
     TextPreferenceWidget(
         title = title,
-        subtitle = subtitle?.format(value),
+        subtitle = if (formatSubtitle) subtitle?.format(value) else subtitle,
         icon = icon,
         onPreferenceClick = { isDialogShown = true },
     )


### PR DESCRIPTION
This pull request includes changes to the `PreferenceItem` and `EditTextPreferenceWidget` classes to add a new `formatSubtitle` parameter. This parameter controls whether the subtitle should be formatted based on the provided value.

Changes to `PreferenceItem` and `EditTextPreferenceWidget`:

* [`app/src/main/java/eu/kanade/presentation/more/settings/PreferenceItem.kt`](diffhunk://#diff-0adb0a2acfd19844dae595a3693fa44d6fc349dd96c68cf19ba183728e321c89R191): Added `formatSubtitle` parameter to the `PreferenceItem` class.
* [`app/src/main/java/eu/kanade/presentation/more/settings/widget/EditTextPreferenceWidget.kt`](diffhunk://#diff-9c0d7a3876e5739b49eb14a7bec87400d7a46f683323df962e2786bc966ab751R40-R46): Added `formatSubtitle` parameter to the `EditTextPreferenceWidget` function and updated the subtitle formatting logic based on this parameter.