### PR TITLE
feat: enhance subtitle management and playback controls in casting UI

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/CastManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/CastManager.kt
@@ -688,7 +688,7 @@ class CastManager(
                 }
 
                 val wasPlaying = client.isPlaying
-val activeTrackIds = client.mediaStatus?.activeTrackIds ?: longArrayOf()
+                val activeTrackIds = client.mediaStatus?.activeTrackIds ?: longArrayOf()
 
                 val styleApplied = suspendCancellableCoroutine { continuation ->
                     val task = client.setTextTrackStyle(textTrackStyle)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/CastManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/CastManager.kt
@@ -688,7 +688,7 @@ class CastManager(
                 }
 
                 val wasPlaying = client.isPlaying
-                val activeTrackIds = client.mediaStatus?.activeTrackIds ?: longArrayOf()
+val activeTrackIds = client.mediaStatus?.activeTrackIds ?: longArrayOf()
 
                 val styleApplied = suspendCancellableCoroutine { continuation ->
                     val task = client.setTextTrackStyle(textTrackStyle)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/CastManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/CastManager.kt
@@ -35,12 +35,14 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import logcat.LogPriority
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.preference.PreferenceStore
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.i18n.tail.TLMR
 import java.util.LinkedList
+import kotlin.coroutines.resume
 
 class CastManager(
     private val activity: ComponentActivity,
@@ -170,9 +172,6 @@ class CastManager(
             override fun onStatusUpdated() {
                 updateCurrentMedia()
                 updateQueueItems()
-                if (session.remoteMediaClient?.hasMediaSession() == true) {
-                    applySubtitleSettings(getDefaultSubtitleSettings())
-                }
             }
 
             override fun onMetadataUpdated() {
@@ -529,26 +528,6 @@ class CastManager(
         }
     }
 
-    fun playPause() {
-        castSession?.remoteMediaClient?.let { client ->
-            val newState = !client.isPaused
-            _isPlaying.value = newState
-            if (newState) {
-                client.play().setResultCallback { result ->
-                    if (!result.status.isSuccess) {
-                        _isPlaying.value = false
-                    }
-                }
-            } else {
-                client.pause().setResultCallback { result ->
-                    if (!result.status.isSuccess) {
-                        _isPlaying.value = true
-                    }
-                }
-            }
-        }
-    }
-
     fun stop() {
         castSession?.remoteMediaClient?.stop()
         _isPlaying.value = false
@@ -626,97 +605,159 @@ class CastManager(
         _castState.value = CastState.DISCONNECTED
     }
 
+    private var lastAppliedSettings: SubtitleSettings? = null
+    private var subtitleSettingsJob: Job? = null
+    
     fun applySubtitleSettings(settings: SubtitleSettings) {
-        try {
-            val session = castSession ?: run {
-                castContext?.sessionManager?.currentCastSession?.let { currentSession ->
-                    castSession = currentSession
-                    currentSession
+        subtitleSettingsJob?.cancel()
+        if (lastAppliedSettings == settings) {
+            logcat(LogPriority.INFO) { "Subtitle settings unchanged, skipping update" }
+            return
+        }
+        lastAppliedSettings = settings
+        
+        subtitleSettingsJob = activity.lifecycleScope.launch {
+            try {
+                val session = castSession ?: run {
+                    castContext?.sessionManager?.currentCastSession?.also { 
+                        castSession = it 
+                    } ?: run {
+                        logcat(LogPriority.ERROR) { "No active cast session found" }
+                        null
+                    }
                 } ?: run {
-                    logcat(LogPriority.ERROR) { "No active cast session found, trying to reconnect..." }
-                    reconnect()
-                    castSession
+                    logcat(LogPriority.ERROR) { "Failed to get cast session" }
+                    return@launch
                 }
-            } ?: run {
-                logcat(LogPriority.ERROR) { "Failed to get cast session" }
-                return
-            }
-            val client = session.remoteMediaClient ?: run {
-                logcat(LogPriority.ERROR) { "No remote media client available" }
-                return
-            }
-            subtitlePreferences.saveTextTrackStyle(settings)
-            activity.lifecycleScope.launch {
-                try {
-                    val textTrackStyle = TextTrackStyle().apply {
-                        fontScale = settings.fontSize.value / 20f
-                        foregroundColor = settings.textColor.toArgb()
-                        backgroundColor = settings.backgroundColor.toArgb()
-                        windowColor = android.graphics.Color.TRANSPARENT
-                        if (settings.shadowRadius.value > 0) {
-                            edgeColor = android.graphics.Color.BLACK
-                            edgeType = when {
-                                settings.shadowRadius.value <= 3 -> TextTrackStyle.EDGE_TYPE_DEPRESSED
-                                settings.shadowRadius.value <= 6 -> TextTrackStyle.EDGE_TYPE_DROP_SHADOW
-                                else -> TextTrackStyle.EDGE_TYPE_OUTLINE
-                            }
-                        } else {
-                            edgeType = TextTrackStyle.EDGE_TYPE_NONE
-                        }
 
-                        when (settings.fontFamily) {
-                            FontFamily.Default -> setFontFamily("SANS_SERIF")
-                            FontFamily.SansSerif -> setFontFamily("SANS_SERIF")
-                            FontFamily.Serif -> setFontFamily("SERIF")
-                            FontFamily.Monospace -> setFontFamily("MONOSPACE")
-                            FontFamily.Cursive -> setFontFamily("CURSIVE")
-                            else -> setFontFamily("SANS_SERIF")
-                        }
+                val client = session.remoteMediaClient ?: run {
+                    logcat(LogPriority.ERROR) { "No remote media client available" }
+                    return@launch
+                }
+                if (!client.hasMediaSession()) {
+                    logcat(LogPriority.ERROR) { "No active media session found" }
+                    return@launch
+                }
 
-                        fontStyle = TextTrackStyle.FONT_STYLE_NORMAL
-                        fontGenericFamily = when (settings.fontFamily) {
-                            FontFamily.SansSerif -> TextTrackStyle.FONT_FAMILY_SANS_SERIF
-                            FontFamily.Serif -> TextTrackStyle.FONT_FAMILY_SERIF
-                            FontFamily.Monospace -> TextTrackStyle.FONT_FAMILY_MONOSPACED_SANS_SERIF
-                            FontFamily.Cursive -> TextTrackStyle.FONT_FAMILY_CURSIVE
-                            else -> TextTrackStyle.FONT_FAMILY_SANS_SERIF
-                        }
+                subtitlePreferences.saveTextTrackStyle(settings)
 
+                val textTrackStyle = TextTrackStyle().apply {
+                    fontScale = settings.fontSize.value / 20f
+                    foregroundColor = settings.textColor.toArgb()
+                    backgroundColor = settings.backgroundColor.toArgb()
+                    windowColor = android.graphics.Color.TRANSPARENT
+                    
+                    if (settings.shadowRadius.value > 0) {
+                        edgeColor = android.graphics.Color.BLACK
+                        edgeType = when {
+                            settings.shadowRadius.value <= 3 -> TextTrackStyle.EDGE_TYPE_DEPRESSED
+                            settings.shadowRadius.value <= 6 -> TextTrackStyle.EDGE_TYPE_DROP_SHADOW
+                            else -> TextTrackStyle.EDGE_TYPE_OUTLINE
+                        }
+                    } else {
+                        edgeType = TextTrackStyle.EDGE_TYPE_NONE
+                    }
+
+                    when (settings.fontFamily) {
+                        FontFamily.Default -> setFontFamily("SANS_SERIF")
+                        FontFamily.SansSerif -> setFontFamily("SANS_SERIF")
+                        FontFamily.Serif -> setFontFamily("SERIF")
+                        FontFamily.Monospace -> setFontFamily("MONOSPACE")
+                        FontFamily.Cursive -> setFontFamily("CURSIVE")
+                        else -> setFontFamily("SANS_SERIF")
+                    }
+
+                    fontStyle = TextTrackStyle.FONT_STYLE_NORMAL
+                    fontGenericFamily = when (settings.fontFamily) {
+                        FontFamily.SansSerif -> TextTrackStyle.FONT_FAMILY_SANS_SERIF
+                        FontFamily.Serif -> TextTrackStyle.FONT_FAMILY_SERIF
+                        FontFamily.Monospace -> TextTrackStyle.FONT_FAMILY_MONOSPACED_SANS_SERIF
+                        FontFamily.Cursive -> TextTrackStyle.FONT_FAMILY_CURSIVE
+                        else -> TextTrackStyle.FONT_FAMILY_SANS_SERIF
+                    }
+
+                    if (settings.borderStyle != BorderStyle.NONE) {
                         edgeType = when (settings.borderStyle) {
-                            BorderStyle.NONE -> TextTrackStyle.EDGE_TYPE_NONE
                             BorderStyle.OUTLINE -> TextTrackStyle.EDGE_TYPE_OUTLINE
                             BorderStyle.DROP_SHADOW -> TextTrackStyle.EDGE_TYPE_DROP_SHADOW
                             BorderStyle.RAISED -> TextTrackStyle.EDGE_TYPE_RAISED
                             BorderStyle.DEPRESSED -> TextTrackStyle.EDGE_TYPE_DEPRESSED
+                            else -> TextTrackStyle.EDGE_TYPE_NONE
                         }
                     }
+                }
 
-                    val wasPlaying = client.isPlaying
-                    val activeTrackIds = client.mediaStatus?.activeTrackIds ?: longArrayOf()
+                val wasPlaying = client.isPlaying
+                val activeTrackIds = client.mediaStatus?.activeTrackIds ?: longArrayOf()
 
-                    val setStyleTask = client.setTextTrackStyle(textTrackStyle)
-                    setStyleTask.addStatusListener { result ->
-                        if (result.isSuccess) {
-                            activity.lifecycleScope.launch {
-                                delay(100)
-                                if (activeTrackIds.isNotEmpty()) {
-                                    val setTracksTask = client.setActiveMediaTracks(longArrayOf())
-                                    setTracksTask.addStatusListener { tracksResult ->
-                                        if (tracksResult.isSuccess && wasPlaying) {
-                                            client.play()
-                                        }
-                                    }
-                                }
+                val styleApplied = suspendCancellableCoroutine { continuation ->
+                    val task = client.setTextTrackStyle(textTrackStyle)
+                    task.setResultCallback { result ->
+                        if (continuation.isActive) {
+                            val success = result.status.isSuccess
+                            continuation.resume(success)
+                        }
+                    }
+                    continuation.invokeOnCancellation {
+                        task.cancel()
+                    }
+                }
+                
+                if (!styleApplied) {
+                    logcat(LogPriority.ERROR) { "Failed to apply text track style" }
+                    return@launch
+                }
+
+                if (activeTrackIds.isNotEmpty()) {
+
+                    val tracksDisabled = suspendCancellableCoroutine { continuation ->
+                        val task = client.setActiveMediaTracks(longArrayOf())
+                        task.setResultCallback { result ->
+                            if (continuation.isActive) {
+                                val success = result.status.isSuccess
+                                continuation.resume(success)
                             }
                         }
+                        continuation.invokeOnCancellation {
+                            task.cancel()
+                        }
                     }
-                    logcat(LogPriority.INFO) { "Successfully applied subtitle settings" }
-                } catch (e: Exception) {
-                    logcat(LogPriority.ERROR) { "Error applying subtitle settings: ${e.message}" }
+                    
+                    if (!tracksDisabled) {
+                        logcat(LogPriority.ERROR) { "Failed to disable tracks" }
+                    } else {
+                        delay(500)
+                        val tracksEnabled = suspendCancellableCoroutine { continuation ->
+                            val task = client.setActiveMediaTracks(activeTrackIds)
+                            task.setResultCallback { result ->
+                                if (continuation.isActive) {
+                                    val success = result.status.isSuccess
+                                    continuation.resume(success)
+                                }
+                            }
+                            continuation.invokeOnCancellation {
+                                task.cancel()
+                            }
+                        }
+                        
+                        if (!tracksEnabled) {
+                            logcat(LogPriority.ERROR) { "Failed to re-enable tracks" }
+                        } else if (wasPlaying) {
+                            delay(100)
+                            client.play()
+                            logcat(LogPriority.INFO) { "Playback resumed" }
+                        }
+                    }
+                } else {
+                    logcat(LogPriority.INFO) { "No active tracks found, skipping refresh" }
                 }
+
+            } catch (e: Exception) {
+                logcat(LogPriority.ERROR) { "Error applying subtitle settings: ${e.message}" }
+                e.printStackTrace()
+            } finally {
+                subtitleSettingsJob = null
             }
-        } catch (e: Exception) {
-            logcat(LogPriority.ERROR) { "Error in applySubtitleSettings: ${e.message}" }
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/CastManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/CastManager.kt
@@ -607,7 +607,7 @@ class CastManager(
 
     private var lastAppliedSettings: SubtitleSettings? = null
     private var subtitleSettingsJob: Job? = null
-    
+
     fun applySubtitleSettings(settings: SubtitleSettings) {
         subtitleSettingsJob?.cancel()
         if (lastAppliedSettings == settings) {
@@ -615,12 +615,12 @@ class CastManager(
             return
         }
         lastAppliedSettings = settings
-        
+
         subtitleSettingsJob = activity.lifecycleScope.launch {
             try {
                 val session = castSession ?: run {
-                    castContext?.sessionManager?.currentCastSession?.also { 
-                        castSession = it 
+                    castContext?.sessionManager?.currentCastSession?.also {
+                        castSession = it
                     } ?: run {
                         logcat(LogPriority.ERROR) { "No active cast session found" }
                         null
@@ -646,7 +646,7 @@ class CastManager(
                     foregroundColor = settings.textColor.toArgb()
                     backgroundColor = settings.backgroundColor.toArgb()
                     windowColor = android.graphics.Color.TRANSPARENT
-                    
+
                     if (settings.shadowRadius.value > 0) {
                         edgeColor = android.graphics.Color.BLACK
                         edgeType = when {
@@ -702,14 +702,13 @@ class CastManager(
                         task.cancel()
                     }
                 }
-                
+
                 if (!styleApplied) {
                     logcat(LogPriority.ERROR) { "Failed to apply text track style" }
                     return@launch
                 }
 
                 if (activeTrackIds.isNotEmpty()) {
-
                     val tracksDisabled = suspendCancellableCoroutine { continuation ->
                         val task = client.setActiveMediaTracks(longArrayOf())
                         task.setResultCallback { result ->
@@ -722,7 +721,7 @@ class CastManager(
                             task.cancel()
                         }
                     }
-                    
+
                     if (!tracksDisabled) {
                         logcat(LogPriority.ERROR) { "Failed to disable tracks" }
                     } else {
@@ -739,7 +738,7 @@ class CastManager(
                                 task.cancel()
                             }
                         }
-                        
+
                         if (!tracksEnabled) {
                             logcat(LogPriority.ERROR) { "Failed to re-enable tracks" }
                         } else if (wasPlaying) {
@@ -751,7 +750,6 @@ class CastManager(
                 } else {
                     logcat(LogPriority.INFO) { "No active tracks found, skipping refresh" }
                 }
-
             } catch (e: Exception) {
                 logcat(LogPriority.ERROR) { "Error applying subtitle settings: ${e.message}" }
                 e.printStackTrace()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/cast/components/ExpandedControllerScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/cast/components/ExpandedControllerScreen.kt
@@ -518,6 +518,7 @@ fun ExpandedControllerScreen(
     if (showTracksDialog) {
         TracksSelectionDialog(
             client = client,
+            castManager = castManager,
             onDismiss = { showTracksDialog = false },
         )
     }
@@ -895,6 +896,7 @@ private fun ExpandedControllerQueueItem(
 @Composable
 private fun TracksSelectionDialog(
     client: RemoteMediaClient?,
+    castManager: CastManager,
     onDismiss: () -> Unit,
 ) {
     val tracks = remember(client) {
@@ -902,6 +904,29 @@ private fun TracksSelectionDialog(
     }
     var activeTrackIds by remember(client) {
         mutableStateOf(client?.mediaStatus?.activeTrackIds?.toSet() ?: emptySet())
+    }
+
+    DisposableEffect(client) {
+        val callback = object : RemoteMediaClient.Callback() {
+            override fun onStatusUpdated() {
+                val currentActiveTrackIds = client?.mediaStatus?.activeTrackIds?.toSet() ?: emptySet()
+                if (currentActiveTrackIds != activeTrackIds) {
+                    activeTrackIds = currentActiveTrackIds
+                    val hasSubtitleTracks = currentActiveTrackIds.any { id ->
+                        tracks.find { it.id == id }?.type == MediaTrack.TYPE_TEXT
+                    }
+                    
+                    if (hasSubtitleTracks) {
+                        castManager.applySubtitleSettings(castManager.getDefaultSubtitleSettings())
+                    }
+                }
+            }
+        }
+        
+        client?.registerCallback(callback)
+        onDispose {
+            client?.unregisterCallback(callback)
+        }
     }
 
     AlertDialog(
@@ -919,6 +944,7 @@ private fun TracksSelectionDialog(
                             style = MaterialTheme.typography.titleMedium,
                             modifier = Modifier.padding(vertical = 8.dp),
                         )
+                        
                         TrackItem(
                             track = null,
                             name = stringResource(TLMR.strings.cast_no_subtitles),
@@ -927,14 +953,16 @@ private fun TracksSelectionDialog(
                             },
                             onSelected = { selected ->
                                 if (selected) {
-                                    activeTrackIds = activeTrackIds.filter { id ->
+                                    val newTrackIds = activeTrackIds.filter { id ->
                                         tracks.find { it.id == id }?.type != MediaTrack.TYPE_TEXT
                                     }.toSet()
-                                    client?.setActiveMediaTracks(activeTrackIds.toLongArray())
+                                    activeTrackIds = newTrackIds
+                                    client?.setActiveMediaTracks(newTrackIds.toLongArray())
                                 }
                             },
                         )
                     }
+                    
                     items(subtitleTracks) { track ->
                         TrackItem(
                             track = track,
@@ -948,6 +976,9 @@ private fun TracksSelectionDialog(
                                 }
                                 activeTrackIds = newTrackIds
                                 client?.setActiveMediaTracks(newTrackIds.toLongArray())
+                                if (selected) {
+                                    castManager.applySubtitleSettings(castManager.getDefaultSubtitleSettings())
+                                }
                             },
                         )
                     }
@@ -961,6 +992,7 @@ private fun TracksSelectionDialog(
                             modifier = Modifier.padding(vertical = 8.dp),
                         )
                     }
+                    
                     items(audioTracks) { track ->
                         TrackItem(
                             track = track,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/cast/components/ExpandedControllerScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/cast/components/ExpandedControllerScreen.kt
@@ -915,14 +915,14 @@ private fun TracksSelectionDialog(
                     val hasSubtitleTracks = currentActiveTrackIds.any { id ->
                         tracks.find { it.id == id }?.type == MediaTrack.TYPE_TEXT
                     }
-                    
+
                     if (hasSubtitleTracks) {
                         castManager.applySubtitleSettings(castManager.getDefaultSubtitleSettings())
                     }
                 }
             }
         }
-        
+
         client?.registerCallback(callback)
         onDispose {
             client?.unregisterCallback(callback)
@@ -944,7 +944,7 @@ private fun TracksSelectionDialog(
                             style = MaterialTheme.typography.titleMedium,
                             modifier = Modifier.padding(vertical = 8.dp),
                         )
-                        
+
                         TrackItem(
                             track = null,
                             name = stringResource(TLMR.strings.cast_no_subtitles),
@@ -962,7 +962,7 @@ private fun TracksSelectionDialog(
                             },
                         )
                     }
-                    
+
                     items(subtitleTracks) { track ->
                         TrackItem(
                             track = track,
@@ -992,7 +992,7 @@ private fun TracksSelectionDialog(
                             modifier = Modifier.padding(vertical = 8.dp),
                         )
                     }
-                    
+
                     items(audioTracks) { track ->
                         TrackItem(
                             track = track,


### PR DESCRIPTION
This pull request includes several updates and improvements to the `CastManager` class and related components in the `app/src/main/java/eu/kanade/tachiyomi/ui/player` directory. The changes focus on enhancing subtitle settings application, optimizing media control logic, and improving the user interface for cast player dialogs.

### Enhancements to Subtitle Settings:

* Added a `lastAppliedSettings` variable to cache the last applied subtitle settings and prevent unnecessary updates. Also introduced a `subtitleSettingsJob` to manage the lifecycle of subtitle settings application. (`[app/src/main/java/eu/kanade/tachiyomi/ui/player/CastManager.ktR608-R649](diffhunk://#diff-49289508bbd77928aec2190163c3fa256ea32b6dc260ea18dc9f7741a64b428cR608-R649)`)
* Improved error handling and logging for subtitle settings application, ensuring that any exceptions are logged and printed. (`[app/src/main/java/eu/kanade/tachiyomi/ui/player/CastManager.ktR608-R649](diffhunk://#diff-49289508bbd77928aec2190163c3fa256ea32b6dc260ea18dc9f7741a64b428cR608-R649)`)
* Replaced the `setResultCallback` method with `suspendCancellableCoroutine` for setting text track styles and active media tracks, allowing for better coroutine management and cancellation handling. (`[app/src/main/java/eu/kanade/tachiyomi/ui/player/CastManager.ktR608-R649](diffhunk://#diff-49289508bbd77928aec2190163c3fa256ea32b6dc260ea18dc9f7741a64b428cR608-R649)`)

### Media Control Logic Optimization:

* Removed the `playPause` function from `CastManager` and replaced its usage with direct calls to `RemoteMediaClient`'s `play` and `pause` methods in the `CastPlayerDialog` component. (`[[1]](diffhunk://#diff-49289508bbd77928aec2190163c3fa256ea32b6dc260ea18dc9f7741a64b428cL532-L551)`, `[[2]](diffhunk://#diff-120f3067fce97f19f9b98387f929e59903088d0fba4ea4b0174c4d6bec2aece7L92-R119)`)
* Added a `LaunchedEffect` in `CastPlayerDialog` to periodically update the `RemoteMediaClient` instance, ensuring that the media client is always up-to-date. (`[app/src/main/java/eu/kanade/tachiyomi/ui/player/cast/components/CastPlayerDialog.ktL47-R68](diffhunk://#diff-120f3067fce97f19f9b98387f929e59903088d0fba4ea4b0174c4d6bec2aece7L47-R68)`)

### User Interface Improvements:

* Updated the `TracksSelectionDialog` to include the `CastManager` instance, allowing for real-time subtitle settings application when subtitle tracks are selected. (`[[1]](diffhunk://#diff-1efdf047bd00be45bf2ec34b3f095626012217811a715e4e9608dde927bc08e1R521)`, `[[2]](diffhunk://#diff-1efdf047bd00be45bf2ec34b3f095626012217811a715e4e9608dde927bc08e1R899)`)
* Added a `DisposableEffect` to register and unregister a `RemoteMediaClient.Callback` in `TracksSelectionDialog`, ensuring that subtitle settings are applied whenever the active track IDs change. (`[app/src/main/java/eu/kanade/tachiyomi/ui/player/cast/components/ExpandedControllerScreen.ktR909-R931](diffhunk://#diff-1efdf047bd00be45bf2ec34b3f095626012217811a715e4e9608dde927bc08e1R909-R931)`)
* Enhanced the track selection logic in `TracksSelectionDialog` to apply subtitle settings when a subtitle track is selected and to update the active track IDs accordingly. (`[[1]](diffhunk://#diff-1efdf047bd00be45bf2ec34b3f095626012217811a715e4e9608dde927bc08e1R979-R981)`, `[[2]](diffhunk://#diff-1efdf047bd00be45bf2ec34b3f095626012217811a715e4e9608dde927bc08e1R995)`)