### PR TITLE
feat(network): Add support for custom DNS-over-HTTPS

### DIFF
--- a/core/common/src/main/java/eu/kanade/tachiyomi/network/DohProviders.kt
+++ b/core/common/src/main/java/eu/kanade/tachiyomi/network/DohProviders.kt
@@ -22,6 +22,7 @@ const val PREF_DOH_CONTROLD = 10
 const val PREF_DOH_NJALLA = 11
 const val PREF_DOH_SHECAN = 12
 const val PREF_DOH_LIBREDNS = 13
+const val PREF_DOH_CUSTOM = 14
 
 fun OkHttpClient.Builder.dohCloudflare() = dns(
     DnsOverHttps.Builder().client(build())
@@ -195,5 +196,20 @@ fun OkHttpClient.Builder.dohLibreDNS() = dns(
             InetAddress.getByName("116.202.176.26"),
             InetAddress.getByName("2a01:4f8:1c0c:8274::1"),
         )
+        .build(),
+)
+
+/**
+ * Build a DoH implementation using a custom user-provided URL.
+ * The URL must be a valid https URL (e.g. "https://example.com/dns-query").
+ */
+fun OkHttpClient.Builder.dohCustom(dohUrl: String, bootstrapHosts: List<java.net.InetAddress> = emptyList()) = dns(
+    DnsOverHttps.Builder().client(build())
+        .url(dohUrl.toHttpUrl())
+        .apply {
+            if (bootstrapHosts.isNotEmpty()) {
+                bootstrapDnsHosts(*bootstrapHosts.toTypedArray())
+            }
+        }
         .build(),
 )

--- a/core/common/src/main/java/eu/kanade/tachiyomi/network/NetworkPreferences.kt
+++ b/core/common/src/main/java/eu/kanade/tachiyomi/network/NetworkPreferences.kt
@@ -26,6 +26,14 @@ class NetworkPreferences(
         return preferenceStore.getInt("doh_provider", -1)
     }
 
+    fun dohCustomUrl(): Preference<String> {
+        return preferenceStore.getString("doh_custom_url", "")
+    }
+
+    fun dohCustomBootstrap(): Preference<String> {
+        return preferenceStore.getString("doh_custom_bootstrap", "")
+    }
+
     fun defaultUserAgent(): Preference<String> {
         return preferenceStore.getString(
             "default_user_agent",

--- a/i18n-tail/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-tail/src/commonMain/moko-resources/base/strings.xml
@@ -367,4 +367,12 @@
     <string name="pref_source_related_animes_summary">Show source-website's Suggestions while viewing entry</string>
     <string name="pref_source_navigation">Replace latest button</string>
     <string name="pref_source_navigation_summery">Replace latest button with a custom browse view that includes both latest and browse</string>
+    <!-- Doh Custom -->
+   <string name="pref_doh_custom_url">Custom DoH URL</string>
+   <string name="pref_doh_custom_url_summary">Example: https://dns.example/dns-query</string>
+   <string name="error_doh_custom_invalid">Invalid DoH URL</string>
+   <string name="error_doh_custom_must_use_https">Custom DoH must use https</string>
+   <string name="pref_doh_custom_bootstrap">Custom DoH bootstrap hosts</string>
+   <string name="pref_doh_custom_bootstrap_summary">Comma separated IPs (optional). Example: 1.1.1.1,8.8.8.8</string>
+   <string name="error_doh_custom_bootstrap_invalid">Invalid bootstrap host: %1$s</string>
 </resources>

--- a/i18n-tail/src/commonMain/moko-resources/es/strings.xml
+++ b/i18n-tail/src/commonMain/moko-resources/es/strings.xml
@@ -311,4 +311,11 @@
   <string name="pref_source_related_animes_summary">Mostrar sugerencias del sitio de origen mientras se ve la entrada</string>
   <string name="pref_source_navigation">Reemplazar el último botón</string>
   <string name="pref_source_navigation_summery">Reemplaza el último botón con una vista de navegación personalizada que incluye tanto la última como la última navegación</string>
+    <string name="pref_doh_custom_url">URL de DoH personalizada</string>
+    <string name="pref_doh_custom_url_summary">Ejemplo: https://dns.example/dns-query</string>
+    <string name="error_doh_custom_invalid">URL de DoH no válida</string>
+    <string name="error_doh_custom_must_use_https">El DoH personalizado debe usar https</string>
+    <string name="pref_doh_custom_bootstrap">Hosts de arranque de DoH personalizados</string>
+    <string name="pref_doh_custom_bootstrap_summary">IP separadas por comas (opcional). Ejemplo: 1.1.1.1,8.8.8.8</string>
+    <string name="error_doh_custom_bootstrap_invalid">Host de arranque no válido: %1$s</string>
 </resources>


### PR DESCRIPTION
Add the ability for users to configure a custom DNS-over-HTTPS (DoH) provider. This includes:
- A setting for the custom DoH URL.
- An optional setting for comma-separated bootstrap IP addresses.
- Validation for the URL (must be HTTPS) and bootstrap hosts.

This provides users with more flexibility for their network configuration.

Closes #289 