### PR TITLE
feat: Animiru tracker & player improvements (#138-142)

### DIFF
--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -306,7 +306,7 @@ class DomainModule : InjektModule {
 
         addSingletonFactory<AnimeTrackRepository> { AnimeTrackRepositoryImpl(get()) }
         addFactory { TrackEpisode(get(), get(), get(), get()) }
-        addFactory { AddAnimeTracks(get(), get(), get(), get()) }
+        addFactory { AddAnimeTracks(get(), get(), get(), get(), get(), get()) }
         addFactory { RefreshAnimeTracks(get(), get(), get(), get()) }
         addFactory { DeleteAnimeTrack(get()) }
         addFactory { GetTracksPerAnime(get()) }

--- a/app/src/main/java/eu/kanade/domain/track/anime/interactor/AddAnimeTracks.kt
+++ b/app/src/main/java/eu/kanade/domain/track/anime/interactor/AddAnimeTracks.kt
@@ -4,6 +4,7 @@ import eu.kanade.domain.entries.anime.interactor.UpdateAnime
 import eu.kanade.domain.track.anime.model.toDbTrack
 import eu.kanade.domain.track.anime.model.toDomainTrack
 import eu.kanade.tachiyomi.animesource.AnimeSource
+import eu.kanade.tachiyomi.animesource.model.FetchType
 import eu.kanade.tachiyomi.data.database.models.anime.AnimeTrack
 import eu.kanade.tachiyomi.data.track.AnimeTracker
 import eu.kanade.tachiyomi.data.track.EnhancedAnimeTracker
@@ -18,6 +19,8 @@ import tachiyomi.domain.entries.anime.interactor.GetAnime
 import tachiyomi.domain.entries.anime.model.Anime
 import tachiyomi.domain.history.anime.interactor.GetAnimeHistory
 import tachiyomi.domain.items.episode.interactor.GetEpisodesByAnimeId
+import tachiyomi.domain.items.season.interactor.GetAnimeSeasonsByParentId
+import tachiyomi.domain.source.anime.service.AnimeSourceManager
 import tachiyomi.domain.track.anime.interactor.InsertAnimeTrack
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -28,12 +31,18 @@ class AddAnimeTracks(
     private val syncChapterProgressWithTrack: SyncEpisodeProgressWithTrack,
     private val getEpisodesByAnimeId: GetEpisodesByAnimeId,
     private val trackerManager: TrackerManager,
+    // AM -->
+    private val getAnimeSeasonsByParentId: GetAnimeSeasonsByParentId,
+    private val sourceManager: AnimeSourceManager,
+    // <-- AM
 ) {
 
     // TODO: update all trackers based on common data
-    suspend fun bind(tracker: AnimeTracker, item: AnimeTrack, animeId: Long) = withNonCancellableContext {
+    // AM -->
+    suspend fun bind(tracker: AnimeTracker, item: AnimeTrack, anime: Anime) = withNonCancellableContext {
+        // <-- AM
         withIOContext {
-            val allChapters = getEpisodesByAnimeId.await(animeId)
+            val allChapters = getEpisodesByAnimeId.await(anime.id)
             val hasSeenEpisodes = allChapters.any { it.seen }
             tracker.bind(item, hasSeenEpisodes)
 
@@ -45,7 +54,7 @@ class AddAnimeTracks(
             try {
                 val updateAnime: UpdateAnime = Injekt.get()
                 val getAnime: GetAnime = Injekt.get()
-                val localAnime = getAnime.await(animeId)
+                val localAnime = getAnime.await(anime.id)
                 val titleForLookup = localAnime?.title
 
                 try {
@@ -53,7 +62,7 @@ class AddAnimeTracks(
                     if (!cast.isNullOrEmpty()) {
                         updateAnime.await(
                             tachiyomi.domain.entries.anime.model.AnimeUpdate(
-                                id = animeId,
+                                id = anime.id,
                                 cast = cast,
                             ),
                         )
@@ -66,66 +75,100 @@ class AddAnimeTracks(
                 logcat(LogPriority.WARN, e) { "Could not fetch/persist cast after binding tracker" }
             }
 
-            // TODO: merge into [SyncChapterProgressWithTrack]?
-            // Update chapter progress if newer chapters marked read locally
-            if (hasSeenEpisodes) {
-                val latestLocalReadChapterNumber = allChapters
-                    .sortedBy { it.episodeNumber }
-                    .takeWhile { it.seen }
-                    .lastOrNull()
-                    ?.episodeNumber ?: -1.0
+            // AM -->
+            when (anime.fetchType) {
+                FetchType.Seasons -> { }
 
-                if (latestLocalReadChapterNumber > track.lastEpisodeSeen) {
-                    track = track.copy(
-                        lastEpisodeSeen = latestLocalReadChapterNumber,
-                    )
-                    tracker.setRemoteLastEpisodeSeen(track.toDbTrack(), latestLocalReadChapterNumber.toInt())
-                }
+                // <-- AM
+                FetchType.Episodes -> {
+                    // TODO: merge into [SyncChapterProgressWithTrack]?
+                    // Update chapter progress if newer chapters marked read locally
+                    if (hasSeenEpisodes) {
+                        val latestLocalReadChapterNumber = allChapters
+                            .sortedBy { it.episodeNumber }
+                            .takeWhile { it.seen }
+                            .lastOrNull()
+                            ?.episodeNumber ?: -1.0
 
-                if (track.startDate <= 0) {
-                    val firstReadChapterDate = Injekt.get<GetAnimeHistory>().await(animeId)
-                        .sortedBy { it.seenAt }
-                        .firstOrNull()
-                        ?.seenAt
+                        if (latestLocalReadChapterNumber > track.lastEpisodeSeen) {
+                            track = track.copy(
+                                lastEpisodeSeen = latestLocalReadChapterNumber,
+                            )
+                            tracker.setRemoteLastEpisodeSeen(track.toDbTrack(), latestLocalReadChapterNumber.toInt())
+                        }
 
-                    firstReadChapterDate?.let {
-                        val startDate = firstReadChapterDate.time.convertEpochMillisZone(
-                            ZoneOffset.systemDefault(),
-                            ZoneOffset.UTC,
-                        )
-                        track = track.copy(
-                            startDate = startDate,
-                        )
-                        tracker.setRemoteStartDate(track.toDbTrack(), startDate)
+                        if (track.startDate <= 0) {
+                            val firstReadChapterDate = Injekt.get<GetAnimeHistory>().await(anime.id)
+                                .sortedBy { it.seenAt }
+                                .firstOrNull()
+                                ?.seenAt
+
+                            firstReadChapterDate?.let {
+                                val startDate = firstReadChapterDate.time.convertEpochMillisZone(
+                                    ZoneOffset.systemDefault(),
+                                    ZoneOffset.UTC,
+                                )
+                                track = track.copy(
+                                    startDate = startDate,
+                                )
+                                tracker.setRemoteStartDate(track.toDbTrack(), startDate)
+                            }
+                        }
                     }
+
+                    syncChapterProgressWithTrack.await(anime.id, track, tracker)
                 }
             }
 
-            syncChapterProgressWithTrack.await(animeId, track, tracker)
+            // AM -->
+            val source = sourceManager.getOrStub(anime.source)
+            bindEnhancedTrackers(anime, source)
+            // <-- AM
         }
     }
 
-    suspend fun bindEnhancedTrackers(anime: Anime, source: AnimeSource) = withNonCancellableContext {
-        withIOContext {
-            trackerManager.trackers
-                .filter { (it as? eu.kanade.tachiyomi.data.track.Tracker)?.isAvailableForUse() == true }
-                .filterIsInstance<EnhancedAnimeTracker>()
-                .filter { it.accept(source) }
-                .forEach { service ->
-                    try {
-                        service.match(anime)?.let { track ->
-                            track.anime_id = anime.id
-                            try {
-                                (service as Tracker).animeService.register(track, anime.id)
-                            } catch (_: Exception) {
-                                // Fallback to previous behavior if register fails for some reason
+    suspend fun bindEnhancedTrackers(anime: Anime, source: AnimeSource) {
+        withNonCancellableContext {
+            withIOContext {
+                trackerManager.trackers
+                    .filter { (it as? eu.kanade.tachiyomi.data.track.Tracker)?.isAvailableForUse() == true }
+                    .filterIsInstance<EnhancedAnimeTracker>()
+                    .filter { it.accept(source) }
+                    .forEach { service ->
+                        try {
+                            // AM -->
+                            val match = when (anime.fetchType) {
+                                FetchType.Seasons -> service.matchSeason(anime)
+                                FetchType.Episodes -> service.match(anime)
+                            }
+                            // <-- AM
+
+                            match?.let { track ->
+                                track.anime_id = anime.id
                                 (service as Tracker).animeService.bind(track)
                                 insertTrack.await(track.toDomainTrack(idRequired = false)!!)
-                            }
 
-                            try {
-                                if (service is AnimeTracker) {
-                                    try {
+                                when (anime.fetchType) {
+                                    // AM -->
+                                    FetchType.Seasons -> {
+                                        val seasons = getAnimeSeasonsByParentId.await(anime.id)
+                                        seasons.filter { it.anime.fetchType == FetchType.Episodes }.forEach { s ->
+                                            bindEnhancedTrackers(s.anime, source)
+                                        }
+                                    }
+
+                                    // <-- AM
+                                    FetchType.Episodes -> {
+                                        syncChapterProgressWithTrack.await(
+                                            anime.id,
+                                            track.toDomainTrack(idRequired = false)!!,
+                                            service.animeService,
+                                        )
+                                    }
+                                }
+
+                                try {
+                                    if (service is AnimeTracker) {
                                         val cast = (service as AnimeTracker).fetchCastByTitle(anime.title)
                                         if (!cast.isNullOrEmpty()) {
                                             Injekt.get<UpdateAnime>().await(
@@ -135,31 +178,21 @@ class AddAnimeTracks(
                                                 ),
                                             )
                                         }
-                                    } catch (e: Exception) {
-                                        logcat(LogPriority.WARN, e) {
-                                            "Could not fetch/persist cast from enhanced tracker"
-                                        }
+                                    }
+                                } catch (e: Exception) {
+                                    logcat(LogPriority.WARN, e) {
+                                        "Could not fetch/persist cast from enhanced tracker"
                                     }
                                 }
-                            } catch (e: Exception) {
-                                logcat(LogPriority.WARN, e) {
-                                    "Could not fetch/persist cast after enhanced tracker bind"
-                                }
                             }
-
-                            syncChapterProgressWithTrack.await(
-                                anime.id,
-                                track.toDomainTrack(idRequired = false)!!,
-                                service.animeService,
-                            )
+                        } catch (e: Exception) {
+                            logcat(
+                                LogPriority.WARN,
+                                e,
+                            ) { "Could not match anime: ${anime.title} with service $service" }
                         }
-                    } catch (e: Exception) {
-                        logcat(
-                            LogPriority.WARN,
-                            e,
-                        ) { "Could not match anime: ${anime.title} with service $service" }
                     }
-                }
+            }
         }
     }
 }

--- a/app/src/main/java/eu/kanade/domain/track/anime/interactor/RefreshAnimeTracks.kt
+++ b/app/src/main/java/eu/kanade/domain/track/anime/interactor/RefreshAnimeTracks.kt
@@ -2,6 +2,7 @@ package eu.kanade.domain.track.anime.interactor
 
 import eu.kanade.domain.track.anime.model.toDbTrack
 import eu.kanade.domain.track.anime.model.toDomainTrack
+import eu.kanade.tachiyomi.data.track.EnhancedAnimeTracker
 import eu.kanade.tachiyomi.data.track.Tracker
 import eu.kanade.tachiyomi.data.track.TrackerManager
 import kotlinx.coroutines.async
@@ -9,6 +10,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.supervisorScope
 import tachiyomi.domain.track.anime.interactor.GetAnimeTracks
 import tachiyomi.domain.track.anime.interactor.InsertAnimeTrack
+import tachiyomi.domain.track.anime.model.AnimeTrack
 
 class RefreshAnimeTracks(
     private val getTracks: GetAnimeTracks,
@@ -22,25 +24,45 @@ class RefreshAnimeTracks(
      *
      * @return Failed updates.
      */
-    suspend fun await(animeId: Long): List<Pair<Tracker?, Throwable>> {
+    suspend fun await(
+        animeId: Long,
+        // AM -->
+        enhancedOnly: Boolean = false,
+        skipCompleted: Boolean = false,
+        // <-- AM
+    ): List<RefreshResult> {
         return supervisorScope {
             return@supervisorScope getTracks.await(animeId)
                 .map { it to trackerManager.get(it.trackerId) }
                 .filter { (_, service) -> service?.isLoggedIn == true }
+                // AM -->
+                .filter { (_, service) -> !enhancedOnly || service is EnhancedAnimeTracker }
+                // <-- AM
                 .map { (track, service) ->
                     async {
                         return@async try {
-                            val updatedTrack = service!!.animeService.refresh(track.toDbTrack()).toDomainTrack()!!
-                            insertTrack.await(updatedTrack)
-                            syncEpisodeProgressWithTrack.await(animeId, updatedTrack, service.animeService)
-                            null
+                            // AM -->
+                            if (!(skipCompleted && track.totalEpisodes == track.lastEpisodeSeen.toLong())) {
+                                // <-- AM
+                                val updatedTrack = service!!.animeService.refresh(track.toDbTrack()).toDomainTrack()!!
+                                insertTrack.await(updatedTrack)
+                                syncEpisodeProgressWithTrack.await(animeId, updatedTrack, service.animeService)
+                            }
+
+                            RefreshResult.Success(track)
                         } catch (e: Throwable) {
-                            service to e
+                            RefreshResult.Failure(service!!, e)
                         }
                     }
                 }
                 .awaitAll()
-                .filterNotNull()
         }
     }
 }
+
+// AM -->
+sealed interface RefreshResult {
+    data class Failure(val tracker: Tracker, val error: Throwable) : RefreshResult
+    data class Success(val track: AnimeTrack) : RefreshResult
+}
+// <-- AM

--- a/app/src/main/java/eu/kanade/domain/track/service/TrackPreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/track/service/TrackPreferences.kt
@@ -54,6 +54,12 @@ class TrackPreferences(
         true,
     )
 
+    // AM -->
+    fun syncEnhancedTrackers() = preferenceStore.getBoolean("sync_enhanced_trackers", true)
+
+    fun smartTrackerSync() = preferenceStore.getBoolean("smart_sync_trackers", true)
+    // <-- AM
+
     val autoUpdateTrackOnMarkRead: Preference<AutoTrackState> = preferenceStore.getEnum(
         "pref_auto_update_manga_on_mark_read",
         AutoTrackState.ALWAYS,

--- a/app/src/main/java/eu/kanade/presentation/entries/anime/AnimeScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/entries/anime/AnimeScreen.kt
@@ -580,6 +580,9 @@ private fun AnimeScreenSmallImpl(
                         AnimeActionRow(
                             favorite = state.anime.favorite,
                             trackingCount = state.trackingCount,
+                            // AM -->
+                            isSyncingTrackers = state.isSyncingTrackers,
+                            // <-- AM
                             nextUpdate = nextUpdate,
                             isUserIntervalMode = state.anime.fetchInterval < 0,
                             onAddToLibraryClicked = onAddToLibraryClicked,
@@ -1019,6 +1022,9 @@ fun AnimeScreenLargeImpl(
                             AnimeActionRow(
                                 favorite = state.anime.favorite,
                                 trackingCount = state.trackingCount,
+                                // AM -->
+                                isSyncingTrackers = state.isSyncingTrackers,
+                                // <-- AM
                                 nextUpdate = nextUpdate,
                                 isUserIntervalMode = state.anime.fetchInterval < 0,
                                 onAddToLibraryClicked = onAddToLibraryClicked,

--- a/app/src/main/java/eu/kanade/presentation/entries/anime/components/AnimeInfoHeader.kt
+++ b/app/src/main/java/eu/kanade/presentation/entries/anime/components/AnimeInfoHeader.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.icons.outlined.Pause
 import androidx.compose.material.icons.outlined.Public
 import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material.icons.outlined.Sync
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
@@ -165,6 +166,9 @@ fun AnimeInfoBox(
 fun AnimeActionRow(
     favorite: Boolean,
     trackingCount: Int,
+    // AM -->
+    isSyncingTrackers: Boolean,
+    // <-- AM
     nextUpdate: Instant?,
     isUserIntervalMode: Boolean,
     onAddToLibraryClicked: () -> Unit,
@@ -216,16 +220,38 @@ fun AnimeActionRow(
             onClick = { onEditIntervalClicked?.invoke() },
         )
         if (onTrackingClicked != null) {
+            // AM -->
             AnimeActionButton(
                 title = if (trackingCount == 0) {
                     stringResource(MR.strings.manga_tracking_tab)
                 } else {
                     pluralStringResource(MR.plurals.num_trackers, count = trackingCount, trackingCount)
                 },
-                icon = if (trackingCount == 0) Icons.Outlined.Sync else Icons.Outlined.Done,
-                color = if (trackingCount == 0) defaultActionButtonColor else MaterialTheme.colorScheme.primary,
+                color = if (isSyncingTrackers) {
+                    MaterialTheme.colorScheme.primary
+                } else if (trackingCount == 0) {
+                    defaultActionButtonColor
+                } else {
+                    MaterialTheme.colorScheme.primary
+                },
                 onClick = onTrackingClicked,
-            )
+            ) {
+                if (isSyncingTrackers) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(20.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                } else {
+                    Icon(
+                        imageVector = if (trackingCount == 0) Icons.Outlined.Sync else Icons.Outlined.Done,
+                        contentDescription = null,
+                        tint = if (trackingCount == 0) defaultActionButtonColor else MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(20.dp),
+                    )
+                }
+            }
+            // <-- AM
         }
 
         if (onWebViewClicked != null) {
@@ -690,18 +716,38 @@ private fun RowScope.AnimeActionButton(
     onClick: () -> Unit,
     onLongClick: (() -> Unit)? = null,
 ) {
+    AnimeActionButton(
+        title = title,
+        color = color,
+        onClick = onClick,
+        onLongClick = onLongClick,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = color,
+            modifier = Modifier.size(20.dp),
+        )
+    }
+}
+
+// AM -->
+@Composable
+private fun RowScope.AnimeActionButton(
+    title: String,
+    color: Color,
+    onClick: () -> Unit,
+    onLongClick: (() -> Unit)? = null,
+    content: @Composable () -> Unit,
+) {
+// <-- AM
     TextButton(
         onClick = onClick,
         modifier = Modifier.weight(1f),
         onLongClick = onLongClick,
     ) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                tint = color,
-                modifier = Modifier.size(20.dp),
-            )
+            content()
             Spacer(Modifier.height(4.dp))
             Text(
                 text = title,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTrackingScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTrackingScreen.kt
@@ -166,6 +166,17 @@ object SettingsTrackingScreen : SearchableSettings {
                     .toPersistentMap(),
                 title = stringResource(AYMR.strings.pref_auto_update_manga_on_mark_read),
             ),
+            // AM -->
+            Preference.PreferenceItem.SwitchPreference(
+                preference = trackPreferences.syncEnhancedTrackers(),
+                title = stringResource(TLMR.strings.pref_tracking_sync_enhanced),
+            ),
+            Preference.PreferenceItem.SwitchPreference(
+                preference = trackPreferences.smartTrackerSync(),
+                title = stringResource(TLMR.strings.pref_smart_sync_tracker),
+                subtitle = stringResource(TLMR.strings.pref_smart_sync_tracker_summary),
+            ),
+            // <-- AM
             Preference.PreferenceGroup(
                 title = stringResource(MR.strings.services),
                 preferenceItems = persistentListOf(

--- a/app/src/main/java/eu/kanade/presentation/track/anime/AnimeTrackInfoDialogHome.kt
+++ b/app/src/main/java/eu/kanade/presentation/track/anime/AnimeTrackInfoDialogHome.kt
@@ -57,6 +57,9 @@ import java.time.format.DateTimeFormatter
 fun AnimeTrackInfoDialogHome(
     trackItems: List<AnimeTrackItem>,
     dateFormat: DateTimeFormatter,
+    // AM -->
+    isSeason: Boolean = false,
+    // <-- AM
     onStatusClick: (AnimeTrackItem) -> Unit,
     onEpisodeClick: (AnimeTrackItem) -> Unit,
     onScoreClick: (AnimeTrackItem) -> Unit,
@@ -85,6 +88,9 @@ fun AnimeTrackInfoDialogHome(
                 TrackInfoItem(
                     title = item.track.title,
                     tracker = item.tracker,
+                    // AM -->
+                    isSeason = isSeason,
+                    // <-- AM
                     status = (item.tracker as? AnimeTracker)?.getStatusForAnime(item.track.status),
                     onStatusClick = { onStatusClick(item) },
                     episodes = "${item.track.lastEpisodeSeen.toInt()}".let {
@@ -135,6 +141,9 @@ fun AnimeTrackInfoDialogHome(
 private fun TrackInfoItem(
     title: String,
     tracker: Tracker,
+    // AM -->
+    isSeason: Boolean = false,
+    // <-- AM
     status: StringResource?,
     onStatusClick: () -> Unit,
     episodes: String,
@@ -211,58 +220,62 @@ private fun TrackInfoItem(
             )
         }
 
-        Box(
-            modifier = Modifier
-                .padding(top = 12.dp)
-                .clip(MaterialTheme.shapes.medium)
-                .background(MaterialTheme.colorScheme.surfaceContainerHighest)
-                .padding(8.dp)
-                .clip(RoundedCornerShape(6.dp)),
-        ) {
-            Column {
-                Row(modifier = Modifier.height(IntrinsicSize.Min)) {
-                    TrackDetailsItem(
-                        modifier = Modifier.weight(1f),
-                        text = status?.let { stringResource(it) } ?: "",
-                        onClick = onStatusClick,
-                    )
-                    VerticalDivider()
-                    TrackDetailsItem(
-                        modifier = Modifier.weight(1f),
-                        text = episodes,
-                        onClick = onEpisodesClick,
-                    )
-                    if (onScoreClick != null) {
+        // AM (hide detail boxes for seasons) -->
+        if (!isSeason) {
+            Box(
+                modifier = Modifier
+                    .padding(top = 12.dp)
+                    .clip(MaterialTheme.shapes.medium)
+                    .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+                    .padding(8.dp)
+                    .clip(RoundedCornerShape(6.dp)),
+            ) {
+                Column {
+                    Row(modifier = Modifier.height(IntrinsicSize.Min)) {
+                        TrackDetailsItem(
+                            modifier = Modifier.weight(1f),
+                            text = status?.let { stringResource(it) } ?: "",
+                            onClick = onStatusClick,
+                        )
                         VerticalDivider()
                         TrackDetailsItem(
                             modifier = Modifier.weight(1f),
-                            text = score,
-                            placeholder = stringResource(MR.strings.score),
-                            onClick = onScoreClick,
+                            text = episodes,
+                            onClick = onEpisodesClick,
                         )
+                        if (onScoreClick != null) {
+                            VerticalDivider()
+                            TrackDetailsItem(
+                                modifier = Modifier.weight(1f),
+                                text = score,
+                                placeholder = stringResource(MR.strings.score),
+                                onClick = onScoreClick,
+                            )
+                        }
                     }
-                }
 
-                if (onStartDateClick != null && onEndDateClick != null) {
-                    HorizontalDivider()
-                    Row(modifier = Modifier.height(IntrinsicSize.Min)) {
-                        TrackDetailsItem(
-                            modifier = Modifier.weight(1F),
-                            text = startDate,
-                            placeholder = stringResource(MR.strings.track_started_reading_date),
-                            onClick = onStartDateClick,
-                        )
-                        VerticalDivider()
-                        TrackDetailsItem(
-                            modifier = Modifier.weight(1F),
-                            text = endDate,
-                            placeholder = stringResource(MR.strings.track_finished_reading_date),
-                            onClick = onEndDateClick,
-                        )
+                    if (onStartDateClick != null && onEndDateClick != null) {
+                        HorizontalDivider()
+                        Row(modifier = Modifier.height(IntrinsicSize.Min)) {
+                            TrackDetailsItem(
+                                modifier = Modifier.weight(1F),
+                                text = startDate,
+                                placeholder = stringResource(MR.strings.track_started_reading_date),
+                                onClick = onStartDateClick,
+                            )
+                            VerticalDivider()
+                            TrackDetailsItem(
+                                modifier = Modifier.weight(1F),
+                                text = endDate,
+                                placeholder = stringResource(MR.strings.track_finished_reading_date),
+                                onClick = onEndDateClick,
+                            )
+                        }
                     }
                 }
             }
         }
+        // <-- AM
     }
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/AnimeTracker.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/AnimeTracker.kt
@@ -14,6 +14,7 @@ import logcat.LogPriority
 import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.lang.withUIContext
 import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.entries.anime.model.Anime
 import tachiyomi.domain.track.anime.interactor.InsertAnimeTrack
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -57,14 +58,16 @@ interface AnimeTracker {
     suspend fun refresh(track: AnimeTrack): AnimeTrack
 
     // TODO: move this to an interactor, and update all trackers based on common data
-    suspend fun register(item: AnimeTrack, animeId: Long) {
-        item.anime_id = animeId
+    // AM -->
+    suspend fun register(item: AnimeTrack, anime: Anime) {
+        item.anime_id = anime.id
         try {
-            addTracks.bind(this, item, animeId)
+            addTracks.bind(this, item, anime)
         } catch (e: Throwable) {
             withUIContext { Injekt.get<Application>().toast(e.message) }
         }
     }
+    // <-- AM
 
     suspend fun setRemoteAnimeStatus(track: AnimeTrack, status: Long) {
         track.status = status

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/EnhancedAnimeTracker.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/EnhancedAnimeTracker.kt
@@ -29,6 +29,14 @@ interface EnhancedAnimeTracker {
      */
     suspend fun match(anime: Anime): AnimeTrackSearch?
 
+    // AM -->
+
+    /**
+     * Similar to [Tracker].search, but only returns zero or one match for seasons.
+     */
+    suspend fun matchSeason(anime: Anime): AnimeTrackSearch?
+    // <-- AM
+
     /**
      * Checks whether the provided source/track/anime triplet is from this AnimeTracker
      */

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/jellyfin/Jellyfin.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/jellyfin/Jellyfin.kt
@@ -101,6 +101,15 @@ class Jellyfin(id: Long) : BaseTracker(id, "Jellyfin"), EnhancedAnimeTracker, An
             null
         }
 
+    // AM -->
+    override suspend fun matchSeason(anime: Anime): AnimeTrackSearch {
+        return AnimeTrackSearch.create(id).apply {
+            title = anime.title
+            tracking_url = anime.url
+        }
+    }
+    // <-- AM
+
     override fun isTrackFrom(track: DomainTrack, anime: Anime, source: AnimeSource?): Boolean =
         track.remoteUrl == anime.url && source?.let { accept(it) } == true
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/jellyfin/JellyfinApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/jellyfin/JellyfinApi.kt
@@ -20,6 +20,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import kotlin.math.abs
+import kotlin.text.split
 
 class JellyfinApi(
     private val trackId: Long,
@@ -33,19 +34,35 @@ class JellyfinApi(
                 val httpUrl = url.toHttpUrl()
                 val fragment = httpUrl.fragment!!
 
-                val track = with(json) {
+                val item = with(json) {
                     client.newCall(GET(url))
                         .awaitSuccess()
                         .parseAs<JFItem>()
-                        .toTrack()
-                }.apply { tracking_url = url }
+                }
+                val track = item.toTrack().apply {
+                    title = item.name
+                    tracking_url = url
+                }
 
                 when {
                     fragment.startsWith("seriesId") -> {
                         getTrackFromSeries(track, httpUrl)
                     }
 
-                    else -> track
+                    // AM -->
+                    fragment.startsWith("movie") -> {
+                        track.apply {
+                            this.total_episodes = 1
+                            this.last_episode_seen = if (item.userData.played) 1.0 else 0.0
+                            this.status = if (item.userData.played) Jellyfin.COMPLETED else Jellyfin.UNSEEN
+                        }
+                    }
+
+                    else -> {
+                        logcat(LogPriority.WARN) { "Could not recognize item: $url" }
+                        throw IllegalArgumentException("Unexpected type: $fragment")
+                    }
+                    // <-- AM
                 }
             } catch (e: Exception) {
                 logcat(LogPriority.WARN, e) { "Could not get item: $url" }
@@ -57,14 +74,6 @@ class JellyfinApi(
         trackId,
     ).also {
         it.title = name
-        it.total_episodes = 1
-        if (userData.played) {
-            it.last_episode_seen = 1.0
-            it.status = Jellyfin.COMPLETED
-        } else {
-            it.last_episode_seen = 0.0
-            it.status = Jellyfin.UNSEEN
-        }
     }
 
     private fun getEpisodesUrl(url: HttpUrl): HttpUrl {
@@ -93,6 +102,15 @@ class JellyfinApi(
                 .parseAs<JFItemList>()
         }.items
 
+        // AM -->
+        if (episodes.isEmpty()) {
+            return track.apply {
+                this.total_episodes = 0
+                this.last_episode_seen = 0.0
+                this.status = Jellyfin.UNSEEN
+            }
+        }
+        // <-- AM
         val totalEpisodes = episodes.last().indexNumber!!
         val firstUnwatched = episodes.indexOfFirst { !it.userData.played }
 
@@ -126,7 +144,9 @@ class JellyfinApi(
         val fragment = httpUrl.fragment!!
 
         val itemId = if (fragment.startsWith("movie")) {
-            httpUrl.pathSegments.last()
+            // AM -->
+            httpUrl.pathSegments.last().takeIf { track.last_episode_seen > 0.0 }
+            // <-- AM
         } else {
             val episodesUrl = getEpisodesUrl(httpUrl)
             val episodes = with(json) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/tmdb/Tmdb.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/tmdb/Tmdb.kt
@@ -16,6 +16,7 @@ import logcat.LogPriority
 import okhttp3.OkHttpClient
 import org.json.JSONObject
 import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.entries.anime.model.Anime
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.aniyomi.AYMR
 import java.util.Locale
@@ -365,7 +366,7 @@ class Tmdb(id: Long) : BaseTracker(id, "TMDB"), AnimeTracker {
         }
     }
 
-    override suspend fun register(item: AnimeTrack, animeId: Long) {
+    override suspend fun register(item: AnimeTrack, anime: Anime) {
         if (item.remote_id == 0L) {
             val url = item.tracking_url
             if (url.isNotBlank()) {
@@ -423,7 +424,7 @@ class Tmdb(id: Long) : BaseTracker(id, "TMDB"), AnimeTracker {
                 }
             }
         }
-        super.register(item, animeId)
+        super.register(item, anime)
     }
 
     override fun isAvailableForUse(): Boolean {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/entries/anime/AnimeScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/entries/anime/AnimeScreen.kt
@@ -234,7 +234,7 @@ class AnimeScreen(
                 } else {
                     screenModel.showTrackDialog()
                 }
-            }.takeIf { successState.anime.fetchType == FetchType.Episodes },
+            },
             onTagSearch = { scope.launch { performGenreSearch(navigator, it, screenModel.source!!) } },
             onFilterButtonClicked = screenModel::showSettingsDialog,
             onRefresh = screenModel::fetchAllFromSource,
@@ -406,6 +406,9 @@ class AnimeScreen(
                         animeId = successState.anime.id,
                         animeTitle = successState.anime.title,
                         sourceId = successState.source.id,
+                        // AM -->
+                        isSeason = successState.anime.fetchType == FetchType.Seasons,
+                        // <-- AM
                     ),
                     enableSwipeDismiss = { it.lastItem is AnimeTrackInfoDialogHomeScreen },
                     onDismissRequest = onDismissRequest,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/entries/anime/AnimeScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/entries/anime/AnimeScreenModel.kt
@@ -30,6 +30,7 @@ import eu.kanade.domain.items.episode.interactor.SyncEpisodesWithSource
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.domain.track.anime.interactor.AddAnimeTracks
 import eu.kanade.domain.track.anime.interactor.RefreshAnimeTracks
+import eu.kanade.domain.track.anime.interactor.RefreshResult
 import eu.kanade.domain.track.anime.interactor.TrackEpisode
 import eu.kanade.domain.track.model.AutoTrackState
 import eu.kanade.domain.track.service.TrackPreferences
@@ -77,6 +78,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
 import logcat.LogPriority
 import mihon.domain.items.episode.interactor.FilterEpisodesForDownload
 import tachiyomi.core.common.i18n.stringResource
@@ -317,6 +319,9 @@ class AnimeScreenModel(
             // Fetch info-episodes when needed
             if (screenModelScope.isActive) {
                 val fetchFromSourceTasks = listOf(
+                    // AM -->
+                    async { syncTrackers() },
+                    // <-- AM
                     async { if (needRefreshInfo) fetchAnimeFromSource() },
                     async { if (needRefreshEpisode || needRefreshSeason) fetchEpisodesAndSeasonsFromSource() },
                 )
@@ -335,6 +340,9 @@ class AnimeScreenModel(
         screenModelScope.launch {
             updateSuccessState { it.copy(isRefreshingData = true) }
             val fetchFromSourceTasks = listOf(
+                // AM -->
+                async { syncTrackers() },
+                // <-- AM
                 async { fetchAnimeFromSource(manualFetch) },
                 async { fetchEpisodesAndSeasonsFromSource(manualFetch) },
             )
@@ -1148,26 +1156,82 @@ class AnimeScreenModel(
         }
     }
 
+    // AM -->
+    private suspend fun syncTrackers() {
+        if (!trackPreferences.syncEnhancedTrackers().get()) return
+        val state = successState ?: return
+        updateSuccessState { it.copy(isSyncingTrackers = true) }
+
+        when (state.anime.fetchType) {
+            FetchType.Seasons -> {
+                if (trackPreferences.smartTrackerSync().get()) {
+                    seasons@ for (s in state.seasons) {
+                        refreshTrackers(animeId = s.seasonAnime.id, enhancedOnly = true, skipCompleted = true)
+                            .filterIsInstance<RefreshResult.Success>()
+                            .onEach {
+                                if (it.track.lastEpisodeSeen.toLong() != it.track.totalEpisodes) {
+                                    break@seasons
+                                }
+                            }
+                    }
+                } else {
+                    state.seasons.chunked(5).forEach { s ->
+                        supervisorScope {
+                            s.map { season ->
+                                async { refreshTrackers(animeId = season.seasonAnime.id, enhancedOnly = true) }
+                            }.awaitAll()
+                        }
+                    }
+                }
+            }
+
+            FetchType.Episodes -> {
+                refreshTrackers(enhancedOnly = true)
+            }
+        }
+
+        updateSuccessState { it.copy(isSyncingTrackers = false) }
+    }
+    // <-- AM
+
+    private suspend fun refreshTrackers(
+        // AM -->
+        enhancedOnly: Boolean = false,
+        skipCompleted: Boolean = false,
+        // <-- AM
+    ): List<RefreshResult> {
+        return refreshTrackers(
+            animeId = animeId,
+            enhancedOnly = enhancedOnly,
+            skipCompleted = skipCompleted,
+        )
+    }
+
+    // AM -->
     private suspend fun refreshTrackers(
         refreshTracks: RefreshAnimeTracks = Injekt.get(),
-    ) {
-        refreshTracks.await(animeId)
-            .filter { it.first != null }
-            .forEach { (track, e) ->
+        animeId: Long,
+        enhancedOnly: Boolean = false,
+        skipCompleted: Boolean = false,
+    ): List<RefreshResult> {
+        return refreshTracks.await(animeId, enhancedOnly, skipCompleted)
+            .onEach {
+                val (track, e) = it as? RefreshResult.Failure ?: return@onEach
                 logcat(LogPriority.ERROR, e) {
-                    "Failed to refresh track data animeId=$animeId for service ${track!!.id}"
+                    "Failed to refresh track data animeId=$animeId for service ${track.id}"
                 }
                 withUIContext {
                     context.toast(
                         context.stringResource(
                             MR.strings.track_error,
-                            track!!.name,
+                            track.name,
                             e.message ?: "",
                         ),
                     )
                 }
             }
     }
+    // <-- AM
 
     /**
      * Downloads the given list of episodes with the manager.
@@ -1709,6 +1773,11 @@ class AnimeScreenModel(
                 val supportedTrackers = loggedInTrackers.filter {
                     (it as? EnhancedAnimeTracker)?.accept(source!!) ?: true
                 }
+                    // AM -->
+                    // For now, only enhanced trackers supports season tracking to sync the seasons.
+                    // This could probably be fleshed out later.
+                    .filter { anime.fetchType == FetchType.Episodes || it is EnhancedAnimeTracker }
+                // <-- AM
                 val supportedTrackerIds = supportedTrackers.map { it.id }.toHashSet()
                 val supportedTrackerTracks = animeTracks.filter { it.trackerId in supportedTrackerIds }
                 supportedTrackerTracks.size to supportedTrackers.isNotEmpty()
@@ -1839,6 +1908,9 @@ class AnimeScreenModel(
             val seasons: List<AnimeSeasonItem>,
             val trackingCount: Int = 0,
             val hasLoggedInTrackers: Boolean = false,
+            // AM -->
+            val isSyncingTrackers: Boolean = false,
+            // <-- AM
             val isRefreshingData: Boolean = false,
             val dialog: Dialog? = null,
             val hasPromptedToAddBefore: Boolean = false,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/entries/anime/track/AnimeTrackInfoDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/entries/anime/track/AnimeTrackInfoDialog.kt
@@ -39,6 +39,7 @@ import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import dev.icerock.moko.resources.StringResource
 import eu.kanade.domain.track.anime.interactor.RefreshAnimeTracks
+import eu.kanade.domain.track.anime.interactor.RefreshResult
 import eu.kanade.domain.track.anime.model.toDbTrack
 import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.presentation.track.TrackDateSelector
@@ -93,12 +94,15 @@ data class AnimeTrackInfoDialogHomeScreen(
     private val animeId: Long,
     private val animeTitle: String,
     private val sourceId: Long,
+    // AM -->
+    private val isSeason: Boolean = false,
+    // <-- AM
 ) : Screen() {
     @Composable
     override fun Content() {
         val navigator = LocalNavigator.currentOrThrow
         val context = LocalContext.current
-        val screenModel = rememberScreenModel { Model(animeId, sourceId) }
+        val screenModel = rememberScreenModel { Model(animeId, sourceId, isSeason = isSeason) }
 
         val dateFormat = remember {
             UiPreferences.dateFormat(
@@ -110,6 +114,9 @@ data class AnimeTrackInfoDialogHomeScreen(
         AnimeTrackInfoDialogHome(
             trackItems = state.trackItems,
             dateFormat = dateFormat,
+            // AM -->
+            isSeason = isSeason,
+            // <-- AM
             onStatusClick = {
                 navigator.push(
                     TrackStatusSelectorScreen(
@@ -201,13 +208,20 @@ data class AnimeTrackInfoDialogHomeScreen(
     private class Model(
         private val animeId: Long,
         private val sourceId: Long,
+        // AM -->
+        private val isSeason: Boolean = false,
+        // <-- AM
         private val getTracks: GetAnimeTracks = Injekt.get(),
     ) : StateScreenModel<Model.State>(State()) {
 
         init {
-            screenModelScope.launch {
-                refreshTrackers()
+            // AM (skip auto-refresh for seasons — handled by syncTrackers) -->
+            if (!isSeason) {
+                screenModelScope.launch {
+                    refreshTrackers()
+                }
             }
+            // <-- AM
 
             screenModelScope.launch {
                 getTracks.subscribe(animeId)
@@ -229,8 +243,14 @@ data class AnimeTrackInfoDialogHomeScreen(
             screenModelScope.launchNonCancellable {
                 val anime = Injekt.get<GetAnime>().await(animeId) ?: return@launchNonCancellable
                 try {
-                    val matchResult = item.tracker.match(anime) ?: throw Exception()
-                    item.tracker.animeService.register(matchResult, animeId)
+                    // AM -->
+                    val matchResult = if (isSeason) {
+                        item.tracker.matchSeason(anime)
+                    } else {
+                        item.tracker.match(anime)
+                    } ?: throw Exception()
+                    item.tracker.animeService.register(matchResult, anime)
+                    // <-- AM
                 } catch (e: Exception) {
                     withUIContext { Injekt.get<Application>().toast(MR.strings.error_no_match) }
                 }
@@ -241,22 +261,24 @@ data class AnimeTrackInfoDialogHomeScreen(
             val refreshTracks = Injekt.get<RefreshAnimeTracks>()
             val context = Injekt.get<Application>()
 
+            // AM -->
             refreshTracks.await(animeId)
-                .filter { it.first != null }
+                .filterIsInstance<RefreshResult.Failure>()
                 .forEach { (track, e) ->
                     logcat(LogPriority.ERROR, e) {
-                        "Failed to refresh track data mangaId=$animeId for service ${track!!.id}"
+                        "Failed to refresh track data animeId=$animeId for service ${track.id}"
                     }
                     withUIContext {
                         context.toast(
                             context.stringResource(
                                 MR.strings.track_error,
-                                track!!.name,
+                                track.name,
                                 e.message ?: "",
                             ),
                         )
                     }
                 }
+            // <-- AM
         }
 
         fun togglePrivate(item: AnimeTrackItem) {
@@ -758,7 +780,12 @@ data class TrackServiceSearchScreen(
         }
 
         fun registerTracking(item: AnimeTrackSearch) {
-            screenModelScope.launchNonCancellable { tracker.animeService.register(item, animeId) }
+            screenModelScope.launchNonCancellable {
+                // AM -->
+                val anime = Injekt.get<GetAnime>().await(animeId) ?: return@launchNonCancellable
+                tracker.animeService.register(item, anime)
+                // <-- AM
+            }
         }
 
         fun updateSelection(selected: AnimeTrackSearch) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/AniyomiMPVView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/AniyomiMPVView.kt
@@ -29,6 +29,7 @@ import eu.kanade.tachiyomi.ui.player.settings.AdvancedPlayerPreferences
 import eu.kanade.tachiyomi.ui.player.settings.AudioPreferences
 import eu.kanade.tachiyomi.ui.player.settings.DecoderPreferences
 import eu.kanade.tachiyomi.ui.player.settings.PlayerPreferences
+import eu.kanade.tachiyomi.ui.player.settings.SubtitleAssOverride
 import eu.kanade.tachiyomi.ui.player.settings.SubtitlePreferences
 import `is`.xyz.mpv.BaseMPVView
 import `is`.xyz.mpv.KeyMapping
@@ -269,9 +270,11 @@ class AniyomiMPVView(context: Context, attributes: AttributeSet) : BaseMPVView(c
         )
 
         MPVLib.setOptionString("sub-font", subtitlePreferences.subtitleFont().get())
-        if (subtitlePreferences.overrideSubsASS().get()) {
-            MPVLib.setOptionString("sub-ass-override", "force")
-            MPVLib.setOptionString("sub-ass-justify", "yes")
+        subtitlePreferences.overrideSubsASS().get().let {
+            MPVLib.setOptionString("sub-ass-override", it.value)
+            if (it != SubtitleAssOverride.No) {
+                MPVLib.setOptionString("sub-ass-justify", "yes")
+            }
         }
         MPVLib.setOptionString("sub-font-size", subtitlePreferences.subtitleFontSize().get().toString())
         MPVLib.setOptionString("sub-bold", if (subtitlePreferences.boldSubtitles().get()) "yes" else "no")

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
@@ -1285,7 +1285,9 @@ class PlayerViewModel @JvmOverloads constructor(
                 _hasNextEpisode.update { _ -> getCurrentEpisodeIndex() != currentPlaylist.value.size - 1 }
 
                 // Write to mpv table
+                val parentTitle = anime.parentId?.let { getAnime.await(it)?.title } ?: ""
                 MPVLib.setPropertyString("user-data/current-anime/anime-title", anime.title)
+                MPVLib.setPropertyString("user-data/current-anime/parent-title", parentTitle)
                 MPVLib.setPropertyInt("user-data/current-anime/intro-length", getAnimeSkipIntroLength())
                 MPVLib.setPropertyString(
                     "user-data/current-anime/category",

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/panels/SubtitleSettingsMiscellaneousCard.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/panels/SubtitleSettingsMiscellaneousCard.kt
@@ -17,7 +17,9 @@
 
 package eu.kanade.tachiyomi.ui.player.controls.components.panels
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -25,9 +27,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AlignVerticalCenter
+import androidx.compose.material.icons.filled.BorderStyle
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.EditOff
 import androidx.compose.material.icons.filled.FormatSize
 import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -40,10 +46,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import eu.kanade.presentation.player.components.ExpandableCard
 import eu.kanade.presentation.player.components.SliderItem
-import eu.kanade.presentation.player.components.SwitchPreference
 import eu.kanade.tachiyomi.ui.player.controls.CARDS_MAX_WIDTH
 import eu.kanade.tachiyomi.ui.player.controls.components.sheets.toFixed
 import eu.kanade.tachiyomi.ui.player.controls.panelCardsColors
+import eu.kanade.tachiyomi.ui.player.settings.SubtitleAssOverride
 import eu.kanade.tachiyomi.ui.player.settings.SubtitlePreferences
 import `is`.xyz.mpv.MPVLib
 import tachiyomi.core.common.preference.deleteAndGet
@@ -72,19 +78,56 @@ fun SubtitlesMiscellaneousCard(modifier: Modifier = Modifier) {
     ) {
         Column {
             var overrideAssSubs by remember {
-                mutableStateOf(MPVLib.getPropertyString("sub-ass-override").also { println(it) } == "force")
+                mutableStateOf(
+                    SubtitleAssOverride.byValue(MPVLib.getPropertyString("sub-ass-override") ?: "no"),
+                )
             }
-            SwitchPreference(
-                overrideAssSubs,
-                onValueChange = {
-                    overrideAssSubs = it
-                    preferences.overrideSubsASS().set(it)
-                    MPVLib.setPropertyString("sub-ass-override", if (it) "force" else "scale")
-                },
-                content = { Text(stringResource(AYMR.strings.player_sheets_sub_override_ass)) },
-                modifier = Modifier
-                    .fillMaxWidth(),
-            )
+            var selectingOverrideAss by remember { mutableStateOf(false) }
+            Box {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable(
+                            onClick = {
+                                selectingOverrideAss = !selectingOverrideAss
+                            },
+                        )
+                        .padding(MaterialTheme.padding.large),
+                ) {
+                    Icon(Icons.Default.BorderStyle, null)
+                    Column {
+                        Text(
+                            text = stringResource(AYMR.strings.player_sheets_sub_override_ass),
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+                        Text(
+                            text = stringResource(overrideAssSubs.titleRes),
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                }
+                DropdownMenu(expanded = selectingOverrideAss, onDismissRequest = { selectingOverrideAss = false }) {
+                    SubtitleAssOverride.entries.forEach { option ->
+                        DropdownMenuItem(
+                            text = { Text(stringResource(option.titleRes)) },
+                            onClick = {
+                                overrideAssSubs = option
+                                preferences.overrideSubsASS().set(option)
+                                MPVLib.setPropertyString("sub-ass-override", option.value)
+                                selectingOverrideAss = false
+                            },
+                            trailingIcon = {
+                                if (overrideAssSubs == option) {
+                                    Icon(
+                                        imageVector = Icons.Default.Check,
+                                        contentDescription = null,
+                                    )
+                                }
+                            },
+                        )
+                    }
+                }
+            }
             var subScale by remember {
                 mutableStateOf(MPVLib.getPropertyDouble("sub-scale").toFloat())
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/panels/SubtitleSettingsTypographyCard.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/panels/SubtitleSettingsTypographyCard.kt
@@ -356,7 +356,6 @@ private val FONT_EXTENSION_REGEX = Regex(""".*\.[ot]tf${'$'}""")
 fun resetTypography(preferences: SubtitlePreferences) {
     MPVLib.setPropertyBoolean("sub-bold", preferences.boldSubtitles().deleteAndGet())
     MPVLib.setPropertyBoolean("sub-italic", preferences.italicSubtitles().deleteAndGet())
-    MPVLib.setPropertyBoolean("sub-ass-justify", preferences.overrideSubsASS().deleteAndGet())
     MPVLib.setPropertyString("sub-justify", preferences.subtitleJustification().deleteAndGet().value)
     MPVLib.setPropertyString("sub-font", preferences.subtitleFont().deleteAndGet())
     MPVLib.setPropertyInt("sub-font-size", preferences.subtitleFontSize().deleteAndGet())

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/SubtitlePreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/settings/SubtitlePreferences.kt
@@ -8,9 +8,11 @@ import androidx.compose.material.icons.filled.FormatAlignJustify
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.vector.ImageVector
+import dev.icerock.moko.resources.StringResource
 import eu.kanade.tachiyomi.ui.player.controls.components.panels.SubtitlesBorderStyle
 import tachiyomi.core.common.preference.PreferenceStore
 import tachiyomi.core.common.preference.getEnum
+import tachiyomi.i18n.tail.TLMR
 
 class SubtitlePreferences(
     private val preferenceStore: PreferenceStore,
@@ -46,11 +48,35 @@ class SubtitlePreferences(
     fun subtitleJustification() = preferenceStore.getEnum("pref_sub_justify", SubtitleJustification.Auto)
     fun subtitlePos() = preferenceStore.getInt("pref_sub_pos", 100)
 
-    fun overrideSubsASS() = preferenceStore.getBoolean("pref_override_subtitles_ass", false)
+    fun overrideSubsASS() = preferenceStore.getEnum("pref_override_subtitles_ass_enum", SubtitleAssOverride.No)
 
     fun subtitlesDelay() = preferenceStore.getInt("pref_subtitles_delay", 0)
     fun subtitlesSpeed() = preferenceStore.getFloat("pref_subtitles_speed", 1f)
     fun subtitlesSecondaryDelay() = preferenceStore.getInt("pref_subtitles_secondary_delay", 0)
+}
+
+enum class SubtitleAssOverride(
+    val value: String,
+    val titleRes: StringResource,
+) {
+    No("no", TLMR.strings.player_sheets_subtitles_ass_no),
+    Yes("yes", TLMR.strings.player_sheets_subtitles_ass_yes),
+    Scale("scale", TLMR.strings.player_sheets_subtitles_ass_scale),
+    Force("force", TLMR.strings.player_sheets_subtitles_ass_force),
+    Strip("strip", TLMR.strings.player_sheets_subtitles_ass_strip),
+    ;
+
+    companion object {
+        fun byValue(value: String): SubtitleAssOverride {
+            return when (value) {
+                "strip" -> Strip
+                "force" -> Force
+                "scale" -> Scale
+                "yes" -> Yes
+                else -> No
+            }
+        }
+    }
 }
 
 enum class SubtitleJustification(

--- a/app/src/main/java/mihon/core/migration/migrations/Migrations.kt
+++ b/app/src/main/java/mihon/core/migration/migrations/Migrations.kt
@@ -49,4 +49,5 @@ val migrations: List<Migration>
         CategoryPreferencesCleanupMigration(),
         InstallationIdMigration(),
         PrefLangMigration(),
+        SubtitleAssEnumMigration(),
     )

--- a/app/src/main/java/mihon/core/migration/migrations/SubtitleAssEnumMigration.kt
+++ b/app/src/main/java/mihon/core/migration/migrations/SubtitleAssEnumMigration.kt
@@ -1,0 +1,30 @@
+package mihon.core.migration.migrations
+
+import android.app.Application
+import androidx.core.content.edit
+import androidx.preference.PreferenceManager
+import eu.kanade.tachiyomi.ui.player.settings.SubtitleAssOverride
+import mihon.core.migration.Migration
+import mihon.core.migration.MigrationContext
+import tachiyomi.core.common.preference.PreferenceStore
+import tachiyomi.core.common.preference.getEnum
+
+class SubtitleAssEnumMigration : Migration {
+    override val version = 131f
+
+    override suspend fun invoke(migrationContext: MigrationContext): Boolean {
+        val context = migrationContext.get<Application>() ?: return false
+        val preferenceStore = migrationContext.get<PreferenceStore>() ?: return false
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+
+        val overrideAss = preferenceStore.getBoolean("pref_override_subtitles_ass", false).get()
+        prefs.edit {
+            remove("pref_override_subtitles_ass")
+            preferenceStore.getEnum("pref_override_subtitles_ass_enum", SubtitleAssOverride.No).set(
+                if (overrideAss) SubtitleAssOverride.Force else SubtitleAssOverride.No,
+            )
+        }
+
+        return true
+    }
+}

--- a/i18n-tail/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-tail/src/commonMain/moko-resources/base/strings.xml
@@ -406,4 +406,16 @@
     <string name="show_splash_ovals_on_double_tap_to_seek">Show ripple when double tap seeking</string>
     <string name="show_seek_icon">Show seek icon</string>
     <string name="show_seek_time">Show seek time</string>
+
+    <!-- Player - subtitles -->
+    <string name="player_sheets_subtitles_ass_no">No</string>
+    <string name="player_sheets_subtitles_ass_yes">Yes</string>
+    <string name="player_sheets_subtitles_ass_scale">Scale</string>
+    <string name="player_sheets_subtitles_ass_force">Force</string>
+    <string name="player_sheets_subtitles_ass_strip">Strip</string>
+
+    <!-- Tracking -->
+    <string name="pref_tracking_sync_enhanced">Sync progress from enhanced trackers</string>
+    <string name="pref_smart_sync_tracker">Smart sync seasons</string>
+    <string name="pref_smart_sync_tracker_summary">Skip completed items and stop at entry in progress</string>
 </resources>

--- a/i18n-tail/src/commonMain/moko-resources/es/strings.xml
+++ b/i18n-tail/src/commonMain/moko-resources/es/strings.xml
@@ -344,4 +344,14 @@
     <string name="network_stream_play">Reproducir transmisión</string>
     <string name="network_stream_reset">Limpiar campos</string>
 
+    <string name="player_sheets_subtitles_ass_no">No</string>
+    <string name="player_sheets_subtitles_ass_yes">Sí</string>
+    <string name="player_sheets_subtitles_ass_scale">Escalar</string>
+    <string name="player_sheets_subtitles_ass_force">Forzar</string>
+    <string name="player_sheets_subtitles_ass_strip">Eliminar</string>
+
+    <string name="pref_tracking_sync_enhanced">Sincronizar progreso desde rastreadores mejorados</string>
+    <string name="pref_smart_sync_tracker">Sincronización inteligente de temporadas</string>
+    <string name="pref_smart_sync_tracker_summary">Omite elementos completados y se detiene en el elemento en curso</string>
+
 </resources>


### PR DESCRIPTION
## Summary

Ports 5 commits from [Animiru](https://github.com/quickdesh/Animiru) adapted to the Aniyomi/Animetail architecture.

---

### feat: Two-way sync, season support, and smart sync for enhanced trackers (#138, #139, #140)

- **Two-way sync** (`#138`): Enhanced trackers (e.g. Jellyfin) now automatically update local progress when fetching episodes.
- **Season support** (`#139`): Tracking dialogs for season-type anime show only relevant fields (hides status, episode count, score, and dates). Enhanced tracker matching uses `matchSeason` instead of `match` for season entries.
- **Smart sync** (`#140`): New preference to sync progress sequentially per season, stopping at the first incomplete entry. Also adds a preference to enable/disable enhanced tracker sync. Includes Jellyfin API fixes for movies and empty episode lists.

**New preferences (Settings → Tracking):**
- *Sync progress from enhanced trackers* — enables two-way sync
- *Smart sync seasons* — stops syncing at the first in-progress season entry

### fix: Migrate SubtitleAssOverride from boolean to enum (#141)

Replaces the boolean `overrideSubsASS` preference with a 4-value enum (`No`, `Yes`, `Scale`, `Force`, `Strip`), giving fine-grained control over MPV's `sub-ass-override` option. Includes a migration from the old boolean value.

### feat: Add parent-title to MPV user-data (#142)

Exposes the parent anime title (for season entries) as `user-data/current-anime/parent-title` in MPV, making it available to scripts and UOSC.

---

## Files changed

| Area | Files |
|---|---|
| Tracker interactors | `AddAnimeTracks`, `RefreshAnimeTracks` |
| Tracker interfaces | `AnimeTracker`, `EnhancedAnimeTracker` |
| Jellyfin | `Jellyfin`, `JellyfinApi` |
| TMDB | `Tmdb` |
| DI | `DomainModule` |
| Preferences | `TrackPreferences` |
| UI – Anime screen | `AnimeScreenModel`, `AnimeScreen` (×2) |
| UI – Components | `AnimeInfoHeader`, `AnimeTrackInfoDialog`, `AnimeTrackInfoDialogHome` |
| UI – Settings | `SettingsTrackingScreen` |
| Player | `AniyomiMPVView`, `PlayerViewModel`, `SubtitlePreferences`, `SubtitleSettingsMiscellaneousCard`, `SubtitleSettingsTypographyCard` |
| Migration | `SubtitleAssEnumMigration`, `Migrations` |
| i18n | `base/strings.xml`, `es/strings.xml` |