### PR TITLE
feat: add related mangas functionality and cover-based theme support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -287,6 +287,7 @@ dependencies {
     implementation(libs.reorderable)
     implementation(libs.bundles.markdown)
     implementation(libs.materialKolor)
+    implementation(libs.androidx.palette)
     implementation(libs.google.api.services.drive)
     implementation(libs.google.api.client.oauth)
 

--- a/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
@@ -1,5 +1,6 @@
 package eu.kanade.domain.ui
 
+import com.materialkolor.PaletteStyle
 import eu.kanade.domain.ui.model.AppTheme
 import eu.kanade.domain.ui.model.NavStyle
 import eu.kanade.domain.ui.model.StartScreen
@@ -68,6 +69,23 @@ class UiPreferences(
     val showHomeOnRelatedAnimes: Preference<Boolean> = preferenceStore.getBoolean("show_home_on_related_animes", true)
 
     val showCast: Preference<Boolean> = preferenceStore.getBoolean("show_cast", true)
+
+    // KMK - Cover-based theme -->
+    val customThemeStyle: Preference<PaletteStyle> =
+        preferenceStore.getEnum("pref_custom_theme_style_key", PaletteStyle.Fidelity)
+
+    val themeCoverBased: Preference<Boolean> =
+        preferenceStore.getBoolean("pref_theme_cover_based_key", true)
+
+    val themeCoverBasedStyle: Preference<PaletteStyle> =
+        preferenceStore.getEnum("pref_theme_cover_based_style_key", PaletteStyle.Vibrant)
+
+    val usePanoramaCoverMangaInfo: Preference<Boolean> =
+        preferenceStore.getBoolean("use_panorama_cover_manga_info", false)
+
+    val topAlignCover: Preference<Boolean> =
+        preferenceStore.getBoolean("top_align_cover", false)
+    // KMK <--
 
     companion object {
         fun dateFormat(format: String): DateTimeFormatter = when (format) {

--- a/app/src/main/java/eu/kanade/presentation/entries/EntryScreenConstants.kt
+++ b/app/src/main/java/eu/kanade/presentation/entries/EntryScreenConstants.kt
@@ -24,5 +24,6 @@ enum class EntryScreenItem {
 
     // KMK -->
     RELATED_ANIMES,
+    RELATED_MANGAS,
     // KMK <--
 }

--- a/app/src/main/java/eu/kanade/presentation/entries/anime/components/AnimeInfoHeader.kt
+++ b/app/src/main/java/eu/kanade/presentation/entries/anime/components/AnimeInfoHeader.kt
@@ -78,12 +78,12 @@ import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
 import coil3.request.crossfade
+import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.presentation.components.DropdownMenu
 import eu.kanade.presentation.entries.components.DotSeparatorText
 import eu.kanade.presentation.entries.components.ItemCover
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.animesource.model.SAnime
-import eu.kanade.tachiyomi.data.coil.useBackground
 import eu.kanade.tachiyomi.util.system.copyToClipboard
 import tachiyomi.domain.entries.anime.model.Anime
 import tachiyomi.i18n.MR
@@ -94,6 +94,8 @@ import tachiyomi.presentation.core.i18n.pluralStringResource
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.clickableNoIndication
 import tachiyomi.presentation.core.util.secondaryItemAlpha
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import kotlin.math.roundToInt
@@ -120,7 +122,6 @@ fun AnimeInfoBox(
         AsyncImage(
             model = ImageRequest.Builder(LocalContext.current)
                 .data(anime)
-                .useBackground(true)
                 .crossfade(true)
                 .build(),
             contentDescription = null,
@@ -378,21 +379,40 @@ private fun AnimeAndSourceTitlesLarge(
     onCoverClick: () -> Unit,
     doSearch: (query: String, global: Boolean) -> Unit,
 ) {
+    // KMK -->
+    val uiPreferences = remember { Injekt.get<UiPreferences>() }
+    val usePanoramaCover = uiPreferences.usePanoramaCoverMangaInfo.get()
+    // KMK <--
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(start = 16.dp, top = appBarPadding + 16.dp, end = 16.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        ItemCover.Book(
-            modifier = Modifier.fillMaxWidth(0.65f),
-            data = ImageRequest.Builder(LocalContext.current)
-                .data(anime)
-                .crossfade(true)
-                .build(),
-            contentDescription = stringResource(MR.strings.manga_cover),
-            onClick = onCoverClick,
-        )
+        // KMK -->
+        if (usePanoramaCover) {
+            ItemCover.Thumb(
+                modifier = Modifier.fillMaxWidth(),
+                data = ImageRequest.Builder(LocalContext.current)
+                    .data(anime)
+                    .crossfade(true)
+                    .build(),
+                contentDescription = stringResource(MR.strings.manga_cover),
+                onClick = onCoverClick,
+            )
+        } else {
+            // KMK <--
+            ItemCover.Book(
+                modifier = Modifier.fillMaxWidth(0.65f),
+                data = ImageRequest.Builder(LocalContext.current)
+                    .data(anime)
+                    .crossfade(true)
+                    .build(),
+                contentDescription = stringResource(MR.strings.manga_cover),
+                onClick = onCoverClick,
+            )
+        }
         Spacer(modifier = Modifier.height(16.dp))
         AnimeContentInfo(
             title = anime.title,
@@ -416,36 +436,67 @@ private fun AnimeAndSourceTitlesSmall(
     onCoverClick: () -> Unit,
     doSearch: (query: String, global: Boolean) -> Unit,
 ) {
-    Row(
+    // KMK -->
+    val uiPreferences = remember { Injekt.get<UiPreferences>() }
+    val usePanoramaCover = uiPreferences.usePanoramaCoverMangaInfo.get()
+    val topAlignCover = uiPreferences.topAlignCover.get()
+    // KMK <--
+
+    Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(start = 16.dp, top = appBarPadding + 16.dp, end = 16.dp),
-        horizontalArrangement = Arrangement.spacedBy(16.dp),
-        verticalAlignment = Alignment.CenterVertically,
     ) {
-        ItemCover.Book(
-            modifier = Modifier
-                .sizeIn(maxWidth = 100.dp)
-                .align(Alignment.Top),
-            data = ImageRequest.Builder(LocalContext.current)
-                .data(anime)
-                .crossfade(true)
-                .build(),
-            contentDescription = stringResource(MR.strings.manga_cover),
-            onClick = onCoverClick,
-        )
-        Column(
-            verticalArrangement = Arrangement.spacedBy(2.dp),
-        ) {
-            AnimeContentInfo(
-                title = anime.title,
-                author = anime.author,
-                artist = anime.artist,
-                status = anime.status,
-                sourceName = sourceName,
-                isStubSource = isStubSource,
-                doSearch = doSearch,
+        // KMK -->
+        if (usePanoramaCover) {
+            // Show panoramic cover at full width first
+            ItemCover.Thumb(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                data = ImageRequest.Builder(LocalContext.current)
+                    .data(anime)
+                    .crossfade(true)
+                    .build(),
+                contentDescription = stringResource(MR.strings.manga_cover),
+                onClick = onCoverClick,
             )
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+        // KMK <--
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // KMK -->
+            if (!usePanoramaCover) {
+                // KMK <--
+                ItemCover.Book(
+                    modifier = Modifier
+                        .sizeIn(maxWidth = 100.dp)
+                        .align(if (topAlignCover) Alignment.Top else Alignment.CenterVertically),
+                    data = ImageRequest.Builder(LocalContext.current)
+                        .data(anime)
+                        .crossfade(true)
+                        .build(),
+                    contentDescription = stringResource(MR.strings.manga_cover),
+                    onClick = onCoverClick,
+                )
+            }
+            Column(
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                AnimeContentInfo(
+                    title = anime.title,
+                    author = anime.author,
+                    artist = anime.artist,
+                    status = anime.status,
+                    sourceName = sourceName,
+                    isStubSource = isStubSource,
+                    doSearch = doSearch,
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/eu/kanade/presentation/entries/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/entries/manga/MangaScreen.kt
@@ -23,13 +23,16 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SmallExtendedFloatingActionButton
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.animateFloatingActionButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -48,9 +51,13 @@ import androidx.compose.ui.util.fastAny
 import androidx.compose.ui.util.fastMap
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
+import eu.kanade.domain.source.service.SourcePreferences
+import eu.kanade.domain.ui.UiPreferences
+import eu.kanade.presentation.browse.anime.RelatedAnimeTitle
 import eu.kanade.presentation.components.relativeDateTimeText
 import eu.kanade.presentation.entries.DownloadAction
 import eu.kanade.presentation.entries.EntryScreenItem
+import eu.kanade.presentation.entries.anime.components.OutlinedButtonWithArrow
 import eu.kanade.presentation.entries.components.EntryBottomActionMenu
 import eu.kanade.presentation.entries.components.EntryToolbar
 import eu.kanade.presentation.entries.components.ItemHeader
@@ -60,6 +67,7 @@ import eu.kanade.presentation.entries.manga.components.ExpandableMangaDescriptio
 import eu.kanade.presentation.entries.manga.components.MangaActionRow
 import eu.kanade.presentation.entries.manga.components.MangaChapterListItem
 import eu.kanade.presentation.entries.manga.components.MangaInfoBox
+import eu.kanade.presentation.entries.manga.components.RelatedMangasRow
 import eu.kanade.presentation.util.formatChapterNumber
 import eu.kanade.tachiyomi.data.download.manga.model.MangaDownload
 import eu.kanade.tachiyomi.source.ConfigurableSource
@@ -74,13 +82,18 @@ import tachiyomi.domain.items.chapter.service.missingChaptersCount
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.source.manga.model.StubMangaSource
 import tachiyomi.i18n.MR
+import tachiyomi.i18n.tail.TLMR
 import tachiyomi.presentation.core.components.TwoPanelBox
 import tachiyomi.presentation.core.components.VerticalFastScroller
 import tachiyomi.presentation.core.components.material.PullRefresh
 import tachiyomi.presentation.core.components.material.Scaffold
+import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.presentation.core.util.collectAsState
 import tachiyomi.presentation.core.util.shouldExpandFAB
 import tachiyomi.source.local.entries.manga.isLocal
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 import java.time.Instant
 
 @Composable
@@ -121,6 +134,13 @@ fun MangaScreen(
     // SY -->
     onEditInfoClicked: () -> Unit,
     // SY <--
+
+    // KMK -->
+    getMangaState: @Composable (Manga) -> State<Manga>,
+    onRelatedMangasScreenClick: () -> Unit,
+    onRelatedMangaClick: (Manga) -> Unit,
+    onRelatedMangaLongClick: (Manga) -> Unit,
+    // KMK <--
 
     // For bottom action menu
     onMultiBookmarkClicked: (List<Chapter>, bookmarked: Boolean) -> Unit,
@@ -179,6 +199,12 @@ fun MangaScreen(
             // SY -->
             onEditInfoClicked = onEditInfoClicked,
             // SY <--
+            // KMK -->
+            getMangaState = getMangaState,
+            onRelatedMangasScreenClick = onRelatedMangasScreenClick,
+            onRelatedMangaClick = onRelatedMangaClick,
+            onRelatedMangaLongClick = onRelatedMangaLongClick,
+            // KMK <--
             onMultiBookmarkClicked = onMultiBookmarkClicked,
             onMultiMarkAsReadClicked = onMultiMarkAsReadClicked,
             onMarkPreviousAsReadClicked = onMarkPreviousAsReadClicked,
@@ -220,6 +246,12 @@ fun MangaScreen(
             // SY -->
             onEditInfoClicked = onEditInfoClicked,
             // SY <--
+            // KMK -->
+            getMangaState = getMangaState,
+            onRelatedMangasScreenClick = onRelatedMangasScreenClick,
+            onRelatedMangaClick = onRelatedMangaClick,
+            onRelatedMangaLongClick = onRelatedMangaLongClick,
+            // KMK <--
             onMultiBookmarkClicked = onMultiBookmarkClicked,
             onMultiMarkAsReadClicked = onMultiMarkAsReadClicked,
             onMarkPreviousAsReadClicked = onMarkPreviousAsReadClicked,
@@ -275,6 +307,13 @@ private fun MangaScreenSmallImpl(
     onEditInfoClicked: () -> Unit,
     // SY <--
 
+    // KMK -->
+    getMangaState: @Composable (Manga) -> State<Manga>,
+    onRelatedMangasScreenClick: () -> Unit,
+    onRelatedMangaClick: (Manga) -> Unit,
+    onRelatedMangaLongClick: (Manga) -> Unit,
+    // KMK <--
+
     // For bottom action menu
     onMultiBookmarkClicked: (List<Chapter>, bookmarked: Boolean) -> Unit,
     onMultiMarkAsReadClicked: (List<Chapter>, markAsRead: Boolean) -> Unit,
@@ -299,6 +338,12 @@ private fun MangaScreenSmallImpl(
             third = state.isAnySelected,
         )
     }
+
+    // KMK -->
+    val relatedMangasEnabled by Injekt.get<SourcePreferences>().relatedAnimes.collectAsState()
+    val expandRelatedMangas by Injekt.get<UiPreferences>().expandRelatedAnimes.collectAsState()
+    val showRelatedMangasInOverflow by Injekt.get<UiPreferences>().relatedAnimesInOverflow.collectAsState()
+    // KMK <--
 
     BackHandler(onBack = {
         if (isAnySelected) {
@@ -463,6 +508,55 @@ private fun MangaScreenSmallImpl(
                         )
                     }
 
+                    // KMK -->
+                    if (state.source !is StubMangaSource &&
+                        relatedMangasEnabled
+                    ) {
+                        if (expandRelatedMangas) {
+                            if (state.relatedMangasSorted?.isNotEmpty() != false) {
+                                item(
+                                    key = "divider_related_mangas_top",
+                                ) { HorizontalDivider() }
+                                item(
+                                    key = EntryScreenItem.RELATED_MANGAS,
+                                    contentType = EntryScreenItem.RELATED_MANGAS,
+                                ) {
+                                    Column {
+                                        RelatedAnimeTitle(
+                                            title = stringResource(TLMR.strings.pref_source_related_mangas),
+                                            subtitle = null,
+                                            onClick = onRelatedMangasScreenClick,
+                                            onLongClick = null,
+                                            modifier = Modifier
+                                                .padding(horizontal = MaterialTheme.padding.medium),
+                                        )
+                                        RelatedMangasRow(
+                                            relatedMangas = state.relatedMangasSorted,
+                                            getMangaState = getMangaState,
+                                            onMangaClick = onRelatedMangaClick,
+                                            onMangaLongClick = onRelatedMangaLongClick,
+                                        )
+                                    }
+                                }
+                                item(
+                                    key = "divider_related_mangas_bottom",
+                                ) { HorizontalDivider() }
+                            }
+                        } else if (!showRelatedMangasInOverflow) {
+                            item(
+                                key = EntryScreenItem.RELATED_MANGAS,
+                                contentType = EntryScreenItem.RELATED_MANGAS,
+                            ) {
+                                OutlinedButtonWithArrow(
+                                    text = stringResource(TLMR.strings.pref_source_related_mangas)
+                                        .uppercase(),
+                                    onClick = onRelatedMangasScreenClick,
+                                )
+                            }
+                        }
+                    }
+                    // KMK <--
+
                     item(
                         key = EntryScreenItem.ITEM_HEADER,
                         contentType = EntryScreenItem.ITEM_HEADER,
@@ -537,6 +631,13 @@ fun MangaScreenLargeImpl(
     onEditInfoClicked: () -> Unit,
     // SY <--
 
+    // KMK -->
+    getMangaState: @Composable (Manga) -> State<Manga>,
+    onRelatedMangasScreenClick: () -> Unit,
+    onRelatedMangaClick: (Manga) -> Unit,
+    onRelatedMangaLongClick: (Manga) -> Unit,
+    // KMK <--
+
     // For bottom action menu
     onMultiBookmarkClicked: (List<Chapter>, bookmarked: Boolean) -> Unit,
     onMultiMarkAsReadClicked: (List<Chapter>, markAsRead: Boolean) -> Unit,
@@ -562,6 +663,12 @@ fun MangaScreenLargeImpl(
             third = state.isAnySelected,
         )
     }
+
+    // KMK -->
+    val relatedMangasEnabled by Injekt.get<SourcePreferences>().relatedAnimes.collectAsState()
+    val expandRelatedMangas by Injekt.get<UiPreferences>().expandRelatedAnimes.collectAsState()
+    val showRelatedMangasInOverflow by Injekt.get<UiPreferences>().relatedAnimesInOverflow.collectAsState()
+    // KMK <--
 
     val insetPadding = WindowInsets.systemBars.only(WindowInsetsSides.Horizontal).asPaddingValues()
     var topBarHeight by remember { mutableIntStateOf(0) }
@@ -705,6 +812,38 @@ fun MangaScreenLargeImpl(
                             onCopyTagToClipboard = onCopyTagToClipboard,
                             onEditNotes = onEditNotesClicked,
                         )
+                        // KMK -->
+                        if (state.source !is StubMangaSource &&
+                            relatedMangasEnabled
+                        ) {
+                            if (expandRelatedMangas) {
+                                if (state.relatedMangasSorted?.isNotEmpty() != false) {
+                                    HorizontalDivider()
+                                    RelatedAnimeTitle(
+                                        title = stringResource(TLMR.strings.pref_source_related_mangas),
+                                        subtitle = null,
+                                        onClick = onRelatedMangasScreenClick,
+                                        onLongClick = null,
+                                        modifier = Modifier
+                                            .padding(horizontal = MaterialTheme.padding.medium),
+                                    )
+                                    RelatedMangasRow(
+                                        relatedMangas = state.relatedMangasSorted,
+                                        getMangaState = getMangaState,
+                                        onMangaClick = onRelatedMangaClick,
+                                        onMangaLongClick = onRelatedMangaLongClick,
+                                    )
+                                    HorizontalDivider()
+                                }
+                            } else if (!showRelatedMangasInOverflow) {
+                                OutlinedButtonWithArrow(
+                                    text = stringResource(TLMR.strings.pref_source_related_mangas)
+                                        .uppercase(),
+                                    onClick = onRelatedMangasScreenClick,
+                                )
+                            }
+                        }
+                        // KMK <--
                     }
                 },
                 endContent = {

--- a/app/src/main/java/eu/kanade/presentation/entries/manga/components/MangaInfoHeader.kt
+++ b/app/src/main/java/eu/kanade/presentation/entries/manga/components/MangaInfoHeader.kt
@@ -354,21 +354,40 @@ private fun MangaAndSourceTitlesLarge(
     onCoverClick: () -> Unit,
     doSearch: (query: String, global: Boolean) -> Unit,
 ) {
+    // KMK -->
+    val uiPreferences = remember { Injekt.get<UiPreferences>() }
+    val usePanoramaCover = uiPreferences.usePanoramaCoverMangaInfo.get()
+    // KMK <--
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(start = 16.dp, top = appBarPadding + 16.dp, end = 16.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        ItemCover.Book(
-            modifier = Modifier.fillMaxWidth(0.65f),
-            data = ImageRequest.Builder(LocalContext.current)
-                .data(manga)
-                .crossfade(true)
-                .build(),
-            contentDescription = stringResource(MR.strings.manga_cover),
-            onClick = onCoverClick,
-        )
+        // KMK -->
+        if (usePanoramaCover) {
+            ItemCover.Thumb(
+                modifier = Modifier.fillMaxWidth(),
+                data = ImageRequest.Builder(LocalContext.current)
+                    .data(manga)
+                    .crossfade(true)
+                    .build(),
+                contentDescription = stringResource(MR.strings.manga_cover),
+                onClick = onCoverClick,
+            )
+        } else {
+            // KMK <--
+            ItemCover.Book(
+                modifier = Modifier.fillMaxWidth(0.65f),
+                data = ImageRequest.Builder(LocalContext.current)
+                    .data(manga)
+                    .crossfade(true)
+                    .build(),
+                contentDescription = stringResource(MR.strings.manga_cover),
+                onClick = onCoverClick,
+            )
+        }
         Spacer(modifier = Modifier.height(16.dp))
         MangaContentInfo(
             title = manga.title,
@@ -392,36 +411,67 @@ private fun MangaAndSourceTitlesSmall(
     onCoverClick: () -> Unit,
     doSearch: (query: String, global: Boolean) -> Unit,
 ) {
-    Row(
+    // KMK -->
+    val uiPreferences = remember { Injekt.get<UiPreferences>() }
+    val usePanoramaCover = uiPreferences.usePanoramaCoverMangaInfo.get()
+    val topAlignCover = uiPreferences.topAlignCover.get()
+    // KMK <--
+
+    Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(start = 16.dp, top = appBarPadding + 16.dp, end = 16.dp),
-        horizontalArrangement = Arrangement.spacedBy(16.dp),
-        verticalAlignment = Alignment.CenterVertically,
     ) {
-        ItemCover.Book(
-            modifier = Modifier
-                .sizeIn(maxWidth = 100.dp)
-                .align(Alignment.Top),
-            data = ImageRequest.Builder(LocalContext.current)
-                .data(manga)
-                .crossfade(true)
-                .build(),
-            contentDescription = stringResource(MR.strings.manga_cover),
-            onClick = onCoverClick,
-        )
-        Column(
-            verticalArrangement = Arrangement.spacedBy(2.dp),
-        ) {
-            MangaContentInfo(
-                title = manga.title,
-                author = manga.author,
-                artist = manga.artist,
-                status = manga.status,
-                sourceName = sourceName,
-                isStubSource = isStubSource,
-                doSearch = doSearch,
+        // KMK -->
+        if (usePanoramaCover) {
+            // Show panoramic cover at full width first
+            ItemCover.Thumb(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                data = ImageRequest.Builder(LocalContext.current)
+                    .data(manga)
+                    .crossfade(true)
+                    .build(),
+                contentDescription = stringResource(MR.strings.manga_cover),
+                onClick = onCoverClick,
             )
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+        // KMK <--
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // KMK -->
+            if (!usePanoramaCover) {
+                // KMK <--
+                ItemCover.Book(
+                    modifier = Modifier
+                        .sizeIn(maxWidth = 100.dp)
+                        .align(if (topAlignCover) Alignment.Top else Alignment.CenterVertically),
+                    data = ImageRequest.Builder(LocalContext.current)
+                        .data(manga)
+                        .crossfade(true)
+                        .build(),
+                    contentDescription = stringResource(MR.strings.manga_cover),
+                    onClick = onCoverClick,
+                )
+            }
+            Column(
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                MangaContentInfo(
+                    title = manga.title,
+                    author = manga.author,
+                    artist = manga.artist,
+                    status = manga.status,
+                    sourceName = sourceName,
+                    isStubSource = isStubSource,
+                    doSearch = doSearch,
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/eu/kanade/presentation/entries/manga/components/RelatedMangasRow.kt
+++ b/app/src/main/java/eu/kanade/presentation/entries/manga/components/RelatedMangasRow.kt
@@ -1,0 +1,129 @@
+package eu.kanade.presentation.entries.manga.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import eu.kanade.presentation.browse.GlobalSearchLoadingResultItem
+import eu.kanade.presentation.browse.InLibraryBadge
+import eu.kanade.presentation.browse.components.EmptyResultItem
+import eu.kanade.presentation.entries.components.ItemCover
+import eu.kanade.presentation.library.components.CommonEntryItemDefaults
+import eu.kanade.presentation.library.components.EntryComfortableGridItem
+import eu.kanade.tachiyomi.ui.entries.manga.RelatedManga
+import tachiyomi.domain.entries.manga.model.Manga
+import tachiyomi.domain.entries.manga.model.MangaCover
+import tachiyomi.domain.entries.manga.model.asMangaCover
+import tachiyomi.presentation.core.components.material.padding
+
+@Composable
+fun RelatedMangasRow(
+    relatedMangas: List<RelatedManga>?,
+    getMangaState: @Composable (Manga) -> State<Manga>,
+    onMangaClick: (Manga) -> Unit,
+    onMangaLongClick: (Manga) -> Unit,
+) {
+    when {
+        relatedMangas == null -> {
+            GlobalSearchLoadingResultItem()
+        }
+
+        relatedMangas.isNotEmpty() -> {
+            RelatedMangaCardRow(
+                relatedMangas = relatedMangas,
+                getManga = { getMangaState(it) },
+                onMangaClick = onMangaClick,
+                onMangaLongClick = onMangaLongClick,
+            )
+        }
+
+        else -> {
+            EmptyResultItem()
+        }
+    }
+}
+
+@Composable
+fun RelatedMangaCardRow(
+    relatedMangas: List<RelatedManga>,
+    getManga: @Composable (Manga) -> State<Manga>,
+    onMangaClick: (Manga) -> Unit,
+    onMangaLongClick: (Manga) -> Unit,
+) {
+    val mangas = relatedMangas.filterIsInstance<RelatedManga.Success>().map { it.mangaList }.flatten()
+    val loading = relatedMangas.filterIsInstance<RelatedManga.Loading>().firstOrNull()
+
+    LazyRow(
+        contentPadding = PaddingValues(MaterialTheme.padding.small),
+        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.extraSmall),
+    ) {
+        items(mangas, key = { "related-row-${it.url.hashCode()}" }) {
+            val manga by getManga(it)
+            MangaRelatedItem(
+                title = manga.title,
+                cover = manga.asMangaCover(),
+                isFavorite = manga.favorite,
+                onClick = { onMangaClick(manga) },
+                onLongClick = { onMangaLongClick(manga) },
+            )
+        }
+        if (loading != null) {
+            item {
+                RelatedMangaLoadingItem()
+            }
+        }
+    }
+}
+
+@Composable
+private fun MangaRelatedItem(
+    title: String,
+    cover: MangaCover,
+    isFavorite: Boolean,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+) {
+    Box(modifier = Modifier.width(96.dp)) {
+        EntryComfortableGridItem(
+            title = title,
+            titleMaxLines = 3,
+            coverData = cover,
+            coverBadgeStart = {
+                InLibraryBadge(enabled = isFavorite)
+            },
+            coverAlpha = if (isFavorite) CommonEntryItemDefaults.BrowseFavoriteCoverAlpha else 1f,
+            onClick = onClick,
+            onLongClick = onLongClick,
+        )
+    }
+}
+
+@Composable
+fun RelatedMangaLoadingItem() {
+    Box(
+        modifier = Modifier
+            .width(96.dp)
+            .aspectRatio(ItemCover.Book.ratio)
+            .padding(vertical = MaterialTheme.padding.medium),
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier
+                .size(16.dp)
+                .align(Alignment.Center),
+            strokeWidth = 2.dp,
+        )
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.core.app.ActivityCompat
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
+import com.materialkolor.PaletteStyle
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.domain.ui.model.AppTheme
@@ -52,6 +53,9 @@ object SettingsAppearanceScreen : SearchableSettings {
             getNavbarGroup(uiPreferences = uiPreferences),
             getForkGroup(uiPreferences = uiPreferences),
             // SY <--
+            // KMK -->
+            getAnimeInfoThemeGroup(uiPreferences = uiPreferences),
+            // KMK <--
         )
     }
 
@@ -78,6 +82,15 @@ object SettingsAppearanceScreen : SearchableSettings {
                     title = stringResource(TLMR.strings.pref_custom_color),
                     subtitle = stringResource(TLMR.strings.custom_color_description),
                     onClick = { navigator.push(AppCustomThemeColorPickerScreen()) },
+                ),
+                Preference.PreferenceItem.ListPreference(
+                    preference = uiPreferences.customThemeStyle,
+                    entries = paletteStyleEntries(),
+                    title = stringResource(TLMR.strings.pref_custom_theme_style),
+                    onValueChanged = {
+                        (context as? Activity)?.let { ActivityCompat.recreate(it) }
+                        true
+                    },
                 ),
             )
         } else {
@@ -311,6 +324,56 @@ object SettingsAppearanceScreen : SearchableSettings {
         )
     }
 // SY <--
+
+    // KMK -->
+    @Composable
+    private fun paletteStyleEntries(): kotlinx.collections.immutable.ImmutableMap<PaletteStyle, String> {
+        return mapOf(
+            PaletteStyle.TonalSpot to stringResource(TLMR.strings.pref_theme_cover_based_style_tonalspot),
+            PaletteStyle.Neutral to stringResource(TLMR.strings.pref_theme_cover_based_style_neutral),
+            PaletteStyle.Vibrant to stringResource(TLMR.strings.pref_theme_cover_based_style_vibrant),
+            PaletteStyle.Expressive to stringResource(TLMR.strings.pref_theme_cover_based_style_expressive),
+            PaletteStyle.Rainbow to stringResource(TLMR.strings.pref_theme_cover_based_style_rainbow),
+            PaletteStyle.FruitSalad to stringResource(TLMR.strings.pref_theme_cover_based_style_fruitsalad),
+            PaletteStyle.Monochrome to stringResource(TLMR.strings.pref_theme_cover_based_style_monochrome),
+            PaletteStyle.Fidelity to stringResource(TLMR.strings.pref_theme_cover_based_style_fidelity),
+            PaletteStyle.Content to stringResource(TLMR.strings.pref_theme_cover_based_style_content),
+        ).toImmutableMap()
+    }
+
+    @Composable
+    private fun getAnimeInfoThemeGroup(
+        uiPreferences: UiPreferences,
+    ): Preference.PreferenceGroup {
+        val themeCoverBased by uiPreferences.themeCoverBased.collectAsState()
+
+        return Preference.PreferenceGroup(
+            title = stringResource(TLMR.strings.pref_anime_info),
+            preferenceItems = persistentListOf(
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = uiPreferences.themeCoverBased,
+                    title = stringResource(TLMR.strings.pref_theme_cover_based),
+                ),
+                Preference.PreferenceItem.ListPreference(
+                    preference = uiPreferences.themeCoverBasedStyle,
+                    entries = paletteStyleEntries(),
+                    title = stringResource(TLMR.strings.pref_theme_cover_based_style),
+                    enabled = themeCoverBased,
+                ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = uiPreferences.usePanoramaCoverMangaInfo,
+                    title = stringResource(TLMR.strings.pref_panorama_cover),
+                    subtitle = stringResource(TLMR.strings.pref_panorama_cover_summary),
+                ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = uiPreferences.topAlignCover,
+                    title = stringResource(TLMR.strings.pref_top_align_cover),
+                    subtitle = stringResource(TLMR.strings.pref_top_align_cover_summary),
+                ),
+            ),
+        )
+    }
+    // KMK <--
 }
 
 private val DateFormats = listOf(

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
@@ -48,14 +48,14 @@ object SettingsAppearanceScreen : SearchableSettings {
 
         return listOf(
             getThemeGroup(uiPreferences = uiPreferences),
+            // KMK -->
+            getAnimeInfoThemeGroup(uiPreferences = uiPreferences),
+            // KMK <--
             getDisplayGroup(uiPreferences = uiPreferences),
             // SY -->
             getNavbarGroup(uiPreferences = uiPreferences),
             getForkGroup(uiPreferences = uiPreferences),
             // SY <--
-            // KMK -->
-            getAnimeInfoThemeGroup(uiPreferences = uiPreferences),
-            // KMK <--
         )
     }
 

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
@@ -133,6 +133,56 @@ object SettingsAppearanceScreen : SearchableSettings {
         )
     }
 
+    // KMK -->
+    @Composable
+    private fun paletteStyleEntries(): kotlinx.collections.immutable.ImmutableMap<PaletteStyle, String> {
+        return mapOf(
+            PaletteStyle.TonalSpot to stringResource(TLMR.strings.pref_theme_cover_based_style_tonalspot),
+            PaletteStyle.Neutral to stringResource(TLMR.strings.pref_theme_cover_based_style_neutral),
+            PaletteStyle.Vibrant to stringResource(TLMR.strings.pref_theme_cover_based_style_vibrant),
+            PaletteStyle.Expressive to stringResource(TLMR.strings.pref_theme_cover_based_style_expressive),
+            PaletteStyle.Rainbow to stringResource(TLMR.strings.pref_theme_cover_based_style_rainbow),
+            PaletteStyle.FruitSalad to stringResource(TLMR.strings.pref_theme_cover_based_style_fruitsalad),
+            PaletteStyle.Monochrome to stringResource(TLMR.strings.pref_theme_cover_based_style_monochrome),
+            PaletteStyle.Fidelity to stringResource(TLMR.strings.pref_theme_cover_based_style_fidelity),
+            PaletteStyle.Content to stringResource(TLMR.strings.pref_theme_cover_based_style_content),
+        ).toImmutableMap()
+    }
+
+    @Composable
+    private fun getAnimeInfoThemeGroup(
+        uiPreferences: UiPreferences,
+    ): Preference.PreferenceGroup {
+        val themeCoverBased by uiPreferences.themeCoverBased.collectAsState()
+
+        return Preference.PreferenceGroup(
+            title = stringResource(TLMR.strings.pref_anime_info),
+            preferenceItems = persistentListOf(
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = uiPreferences.themeCoverBased,
+                    title = stringResource(TLMR.strings.pref_theme_cover_based),
+                ),
+                Preference.PreferenceItem.ListPreference(
+                    preference = uiPreferences.themeCoverBasedStyle,
+                    entries = paletteStyleEntries(),
+                    title = stringResource(TLMR.strings.pref_theme_cover_based_style),
+                    enabled = themeCoverBased,
+                ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = uiPreferences.usePanoramaCoverMangaInfo,
+                    title = stringResource(TLMR.strings.pref_panorama_cover),
+                    subtitle = stringResource(TLMR.strings.pref_panorama_cover_summary),
+                ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = uiPreferences.topAlignCover,
+                    title = stringResource(TLMR.strings.pref_top_align_cover),
+                    subtitle = stringResource(TLMR.strings.pref_top_align_cover_summary),
+                ),
+            ),
+        )
+    }
+    // KMK <--
+
     @Composable
     private fun getDisplayGroup(
         uiPreferences: UiPreferences,
@@ -324,56 +374,6 @@ object SettingsAppearanceScreen : SearchableSettings {
         )
     }
 // SY <--
-
-    // KMK -->
-    @Composable
-    private fun paletteStyleEntries(): kotlinx.collections.immutable.ImmutableMap<PaletteStyle, String> {
-        return mapOf(
-            PaletteStyle.TonalSpot to stringResource(TLMR.strings.pref_theme_cover_based_style_tonalspot),
-            PaletteStyle.Neutral to stringResource(TLMR.strings.pref_theme_cover_based_style_neutral),
-            PaletteStyle.Vibrant to stringResource(TLMR.strings.pref_theme_cover_based_style_vibrant),
-            PaletteStyle.Expressive to stringResource(TLMR.strings.pref_theme_cover_based_style_expressive),
-            PaletteStyle.Rainbow to stringResource(TLMR.strings.pref_theme_cover_based_style_rainbow),
-            PaletteStyle.FruitSalad to stringResource(TLMR.strings.pref_theme_cover_based_style_fruitsalad),
-            PaletteStyle.Monochrome to stringResource(TLMR.strings.pref_theme_cover_based_style_monochrome),
-            PaletteStyle.Fidelity to stringResource(TLMR.strings.pref_theme_cover_based_style_fidelity),
-            PaletteStyle.Content to stringResource(TLMR.strings.pref_theme_cover_based_style_content),
-        ).toImmutableMap()
-    }
-
-    @Composable
-    private fun getAnimeInfoThemeGroup(
-        uiPreferences: UiPreferences,
-    ): Preference.PreferenceGroup {
-        val themeCoverBased by uiPreferences.themeCoverBased.collectAsState()
-
-        return Preference.PreferenceGroup(
-            title = stringResource(TLMR.strings.pref_anime_info),
-            preferenceItems = persistentListOf(
-                Preference.PreferenceItem.SwitchPreference(
-                    preference = uiPreferences.themeCoverBased,
-                    title = stringResource(TLMR.strings.pref_theme_cover_based),
-                ),
-                Preference.PreferenceItem.ListPreference(
-                    preference = uiPreferences.themeCoverBasedStyle,
-                    entries = paletteStyleEntries(),
-                    title = stringResource(TLMR.strings.pref_theme_cover_based_style),
-                    enabled = themeCoverBased,
-                ),
-                Preference.PreferenceItem.SwitchPreference(
-                    preference = uiPreferences.usePanoramaCoverMangaInfo,
-                    title = stringResource(TLMR.strings.pref_panorama_cover),
-                    subtitle = stringResource(TLMR.strings.pref_panorama_cover_summary),
-                ),
-                Preference.PreferenceItem.SwitchPreference(
-                    preference = uiPreferences.topAlignCover,
-                    title = stringResource(TLMR.strings.pref_top_align_cover),
-                    subtitle = stringResource(TLMR.strings.pref_top_align_cover_summary),
-                ),
-            ),
-        )
-    }
-    // KMK <--
 }
 
 private val DateFormats = listOf(

--- a/app/src/main/java/eu/kanade/presentation/theme/CoverBasedTheme.kt
+++ b/app/src/main/java/eu/kanade/presentation/theme/CoverBasedTheme.kt
@@ -61,7 +61,7 @@ private fun CoverBasedThemeImpl(
 
     var coverColorScheme by remember { mutableStateOf<ColorScheme?>(null) }
 
-    LaunchedEffect(thumbnailUrl, style) {
+    LaunchedEffect(coverData, thumbnailUrl, style, isDark, isAmoled) {
         thumbnailUrl ?: return@LaunchedEffect
         try {
             val request = ImageRequest.Builder(context)

--- a/app/src/main/java/eu/kanade/presentation/theme/CoverBasedTheme.kt
+++ b/app/src/main/java/eu/kanade/presentation/theme/CoverBasedTheme.kt
@@ -1,0 +1,109 @@
+package eu.kanade.presentation.theme
+
+import android.graphics.Bitmap
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.MaterialExpressiveTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.palette.graphics.Palette
+import coil3.imageLoader
+import coil3.request.ImageRequest
+import coil3.request.SuccessResult
+import coil3.toBitmap
+import eu.kanade.domain.ui.UiPreferences
+import eu.kanade.presentation.theme.colorscheme.CustomCompatColorScheme
+import tachiyomi.domain.entries.anime.model.Anime
+import tachiyomi.domain.entries.manga.model.Manga
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+@Composable
+fun CoverBasedTheme(
+    anime: Anime,
+    content: @Composable () -> Unit,
+) {
+    CoverBasedThemeImpl(coverData = anime, thumbnailUrl = anime.thumbnailUrl, content = content)
+}
+
+@Composable
+fun CoverBasedTheme(
+    manga: Manga,
+    content: @Composable () -> Unit,
+) {
+    CoverBasedThemeImpl(coverData = manga, thumbnailUrl = manga.thumbnailUrl, content = content)
+}
+
+@Composable
+private fun CoverBasedThemeImpl(
+    coverData: Any,
+    thumbnailUrl: String?,
+    content: @Composable () -> Unit,
+) {
+    val uiPreferences = Injekt.get<UiPreferences>()
+    val enabled = uiPreferences.themeCoverBased.get()
+
+    if (!enabled) {
+        content()
+        return
+    }
+
+    val context = LocalContext.current
+    val isDark = isSystemInDarkTheme()
+    val isAmoled = uiPreferences.themeDarkAmoled.get()
+    val style = uiPreferences.themeCoverBasedStyle.get()
+
+    var coverColorScheme by remember { mutableStateOf<ColorScheme?>(null) }
+
+    LaunchedEffect(thumbnailUrl, style) {
+        thumbnailUrl ?: return@LaunchedEffect
+        try {
+            val request = ImageRequest.Builder(context)
+                .data(coverData)
+                .build()
+            val result = context.imageLoader.execute(request)
+            if (result is SuccessResult) {
+                val bitmap = result.image.toBitmap().copy(Bitmap.Config.ARGB_8888, false)
+                val palette = Palette.from(bitmap).generate()
+                val dominantColor = palette.getDominantColor(
+                    palette.getVibrantColor(
+                        palette.getMutedColor(0xFF6200EE.toInt()),
+                    ),
+                )
+                coverColorScheme = CustomCompatColorScheme.generateColorSchemeFromSeed(
+                    seed = Color(dominantColor),
+                    dark = isDark,
+                    style = style,
+                ).let { scheme ->
+                    if (isAmoled && isDark) {
+                        scheme.copy(
+                            background = Color.Black,
+                            surface = Color.Black,
+                            surfaceVariant = Color.Black,
+                        )
+                    } else {
+                        scheme
+                    }
+                }
+            }
+        } catch (_: Exception) {
+            // Fallback: use current theme
+        }
+    }
+
+    val colorScheme = coverColorScheme
+    if (colorScheme != null) {
+        MaterialExpressiveTheme(
+            colorScheme = colorScheme,
+            content = content,
+        )
+    } else {
+        content()
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/theme/colorscheme/CustomColorScheme.kt
+++ b/app/src/main/java/eu/kanade/presentation/theme/colorscheme/CustomColorScheme.kt
@@ -1,18 +1,19 @@
 package eu.kanade.presentation.theme.colorscheme
 
-import android.annotation.SuppressLint
 import androidx.compose.material3.ColorScheme
 import androidx.compose.ui.graphics.Color
-import com.google.android.material.color.utilities.Hct
-import com.google.android.material.color.utilities.MaterialDynamicColors
-import com.google.android.material.color.utilities.SchemeContent
+import com.materialkolor.PaletteStyle
+import com.materialkolor.dynamiccolor.ColorSpec
+import com.materialkolor.ktx.DynamicScheme
+import com.materialkolor.toColorScheme
 import eu.kanade.domain.ui.UiPreferences
 
 internal class CustomColorScheme(uiPreferences: UiPreferences) : BaseColorScheme() {
 
     private val seed = uiPreferences.colorTheme.get()
+    private val style = uiPreferences.customThemeStyle.get()
 
-    private val custom = CustomCompatColorScheme(seed)
+    private val custom = CustomCompatColorScheme(seed, style)
 
     override val darkScheme
         get() = custom.darkScheme
@@ -21,60 +22,24 @@ internal class CustomColorScheme(uiPreferences: UiPreferences) : BaseColorScheme
         get() = custom.lightScheme
 }
 
-private class CustomCompatColorScheme(seed: Int) : BaseColorScheme() {
+internal class CustomCompatColorScheme(seed: Int, style: PaletteStyle = PaletteStyle.Fidelity) : BaseColorScheme() {
 
-    override val lightScheme = generateColorSchemeFromSeed(seed = seed, dark = false)
-    override val darkScheme = generateColorSchemeFromSeed(seed = seed, dark = true)
+    override val lightScheme = generateColorSchemeFromSeed(seed = Color(seed), dark = false, style = style)
+    override val darkScheme = generateColorSchemeFromSeed(seed = Color(seed), dark = true, style = style)
 
     companion object {
-        private fun Int.toComposeColor(): Color = Color(this)
-
-        @SuppressLint("RestrictedApi")
-        private fun generateColorSchemeFromSeed(seed: Int, dark: Boolean): ColorScheme {
-            val scheme = SchemeContent(
-                Hct.fromInt(seed),
-                dark,
-                0.0,
+        fun generateColorSchemeFromSeed(
+            seed: Color,
+            dark: Boolean,
+            style: PaletteStyle = PaletteStyle.Fidelity,
+        ): ColorScheme {
+            return DynamicScheme(
+                seedColor = seed,
+                isDark = dark,
+                specVersion = ColorSpec.SpecVersion.SPEC_2025,
+                style = style,
             )
-            val dynamicColors = MaterialDynamicColors()
-            return ColorScheme(
-                primary = dynamicColors.primary().getArgb(scheme).toComposeColor(),
-                onPrimary = dynamicColors.onPrimary().getArgb(scheme).toComposeColor(),
-                primaryContainer = dynamicColors.primaryContainer().getArgb(scheme).toComposeColor(),
-                onPrimaryContainer = dynamicColors.onPrimaryContainer().getArgb(scheme).toComposeColor(),
-                inversePrimary = dynamicColors.inversePrimary().getArgb(scheme).toComposeColor(),
-                secondary = dynamicColors.secondary().getArgb(scheme).toComposeColor(),
-                onSecondary = dynamicColors.onSecondary().getArgb(scheme).toComposeColor(),
-                secondaryContainer = dynamicColors.secondaryContainer().getArgb(scheme).toComposeColor(),
-                onSecondaryContainer = dynamicColors.onSecondaryContainer().getArgb(scheme).toComposeColor(),
-                tertiary = dynamicColors.tertiary().getArgb(scheme).toComposeColor(),
-                onTertiary = dynamicColors.onTertiary().getArgb(scheme).toComposeColor(),
-                tertiaryContainer = dynamicColors.tertiary().getArgb(scheme).toComposeColor(),
-                onTertiaryContainer = dynamicColors.onTertiaryContainer().getArgb(scheme).toComposeColor(),
-                background = dynamicColors.background().getArgb(scheme).toComposeColor(),
-                onBackground = dynamicColors.onBackground().getArgb(scheme).toComposeColor(),
-                surface = dynamicColors.surface().getArgb(scheme).toComposeColor(),
-                onSurface = dynamicColors.onSurface().getArgb(scheme).toComposeColor(),
-                surfaceVariant = dynamicColors.surfaceVariant().getArgb(scheme).toComposeColor(),
-                onSurfaceVariant = dynamicColors.onSurfaceVariant().getArgb(scheme).toComposeColor(),
-                surfaceTint = dynamicColors.surfaceTint().getArgb(scheme).toComposeColor(),
-                inverseSurface = dynamicColors.inverseSurface().getArgb(scheme).toComposeColor(),
-                inverseOnSurface = dynamicColors.inverseOnSurface().getArgb(scheme).toComposeColor(),
-                error = dynamicColors.error().getArgb(scheme).toComposeColor(),
-                onError = dynamicColors.onError().getArgb(scheme).toComposeColor(),
-                errorContainer = dynamicColors.errorContainer().getArgb(scheme).toComposeColor(),
-                onErrorContainer = dynamicColors.onErrorContainer().getArgb(scheme).toComposeColor(),
-                outline = dynamicColors.outline().getArgb(scheme).toComposeColor(),
-                outlineVariant = dynamicColors.outlineVariant().getArgb(scheme).toComposeColor(),
-                scrim = Color.Black,
-                surfaceBright = dynamicColors.surfaceBright().getArgb(scheme).toComposeColor(),
-                surfaceDim = dynamicColors.surfaceDim().getArgb(scheme).toComposeColor(),
-                surfaceContainer = dynamicColors.surfaceContainer().getArgb(scheme).toComposeColor(),
-                surfaceContainerHigh = dynamicColors.surfaceContainerHigh().getArgb(scheme).toComposeColor(),
-                surfaceContainerHighest = dynamicColors.surfaceContainerHighest().getArgb(scheme).toComposeColor(),
-                surfaceContainerLow = dynamicColors.surfaceContainerLow().getArgb(scheme).toComposeColor(),
-                surfaceContainerLowest = dynamicColors.surfaceContainerLowest().getArgb(scheme).toComposeColor(),
-            )
+                .toColorScheme(isAmoled = false)
         }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/entries/anime/AnimeScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/entries/anime/AnimeScreen.kt
@@ -43,6 +43,7 @@ import eu.kanade.presentation.entries.components.DeleteItemsDialog
 import eu.kanade.presentation.entries.components.SetDateDialog
 import eu.kanade.presentation.entries.components.SetIntervalDialog
 import eu.kanade.presentation.more.settings.screen.player.PlayerSettingsGesturesScreen.SkipIntroLengthDialog
+import eu.kanade.presentation.theme.CoverBasedTheme
 import eu.kanade.presentation.theme.TachiyomiTheme
 import eu.kanade.presentation.util.AssistContentScreen
 import eu.kanade.presentation.util.Screen
@@ -155,7 +156,9 @@ class AnimeScreen(
             }
         }
         TachiyomiTheme {
-            content()
+            CoverBasedTheme(anime = successState.anime) {
+                content()
+            }
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/MangaScreen.kt
@@ -68,7 +68,6 @@ import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import logcat.LogPriority
-import tachiyomi.core.common.preference.invoke
 import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.system.logcat

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/MangaScreen.kt
@@ -29,7 +29,6 @@ import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.core.util.ifMangaSourcesLoaded
 import eu.kanade.domain.entries.manga.model.hasCustomCover
 import eu.kanade.domain.entries.manga.model.toSManga
-import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.presentation.category.components.ChangeCategoryDialog
 import eu.kanade.presentation.components.NavigatorAdaptiveSheet
 import eu.kanade.presentation.entries.EditCoverAction

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/MangaScreen.kt
@@ -1,8 +1,10 @@
 package eu.kanade.tachiyomi.ui.entries.manga
 
 import android.content.Context
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -11,6 +13,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
@@ -26,6 +29,7 @@ import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.core.util.ifMangaSourcesLoaded
 import eu.kanade.domain.entries.manga.model.hasCustomCover
 import eu.kanade.domain.entries.manga.model.toSManga
+import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.presentation.category.components.ChangeCategoryDialog
 import eu.kanade.presentation.components.NavigatorAdaptiveSheet
 import eu.kanade.presentation.entries.EditCoverAction
@@ -37,6 +41,8 @@ import eu.kanade.presentation.entries.manga.DuplicateMangaDialog
 import eu.kanade.presentation.entries.manga.MangaScreen
 import eu.kanade.presentation.entries.manga.components.MangaCoverDialog
 import eu.kanade.presentation.entries.manga.components.ScanlatorFilterDialog
+import eu.kanade.presentation.theme.CoverBasedTheme
+import eu.kanade.presentation.theme.TachiyomiTheme
 import eu.kanade.presentation.util.AssistContentScreen
 import eu.kanade.presentation.util.Screen
 import eu.kanade.presentation.util.isTabletUi
@@ -59,13 +65,18 @@ import eu.kanade.tachiyomi.ui.webview.WebViewScreen
 import eu.kanade.tachiyomi.util.system.copyToClipboard
 import eu.kanade.tachiyomi.util.system.toShareIntent
 import eu.kanade.tachiyomi.util.system.toast
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import logcat.LogPriority
+import tachiyomi.core.common.preference.invoke
+import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.entries.manga.model.Manga
 import tachiyomi.domain.items.chapter.model.Chapter
 import tachiyomi.presentation.core.screens.LoadingScreen
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 
 class MangaScreen(
     private val mangaId: Long,
@@ -85,7 +96,6 @@ class MangaScreen(
 
         val navigator = LocalNavigator.currentOrThrow
         val context = LocalContext.current
-        val haptic = LocalHapticFeedback.current
         val scope = rememberCoroutineScope()
         val lifecycleOwner = LocalLifecycleOwner.current
         val screenModel =
@@ -113,70 +123,46 @@ class MangaScreen(
             }
         }
 
-        MangaScreen(
-            state = successState,
-            snackbarHostState = screenModel.snackbarHostState,
-            nextUpdate = successState.manga.expectedNextUpdate,
-            isTabletUi = isTabletUi(),
-            chapterSwipeStartAction = screenModel.chapterSwipeStartAction,
-            chapterSwipeEndAction = screenModel.chapterSwipeEndAction,
-            navigateUp = navigator::pop,
-            onChapterClicked = { openChapter(context, it) },
-            onDownloadChapter = screenModel::runChapterDownloadActions.takeIf { !successState.source.isLocalOrStub() },
-            onAddToLibraryClicked = {
-                screenModel.toggleFavorite()
-                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-            },
-            onWebViewClicked = {
-                openMangaInWebView(
-                    navigator,
-                    screenModel.manga,
-                    screenModel.source,
-                )
-            }.takeIf { isHttpSource },
-            onWebViewLongClicked = {
-                copyMangaUrl(
-                    context,
-                    screenModel.manga,
-                    screenModel.source,
-                )
-            }.takeIf { isHttpSource },
-            onTrackingClicked = {
-                if (!successState.hasLoggedInTrackers) {
-                    navigator.push(SettingsScreen(SettingsScreen.Destination.Tracking))
-                } else {
-                    screenModel.showTrackDialog()
+        // KMK -->
+        val showingRelatedMangasScreen = rememberSaveable { mutableStateOf(false) }
+
+        BackHandler(showingRelatedMangasScreen.value) {
+            when {
+                showingRelatedMangasScreen.value -> showingRelatedMangasScreen.value = false
+            }
+        }
+
+        val content = @Composable {
+            Crossfade(
+                targetState = showingRelatedMangasScreen.value,
+                label = "manga_related_crossfade",
+            ) { showRelatedMangasScreen ->
+                when (showRelatedMangasScreen) {
+                    true -> RelatedMangasScreen(
+                        screenModel = screenModel,
+                        successState = successState,
+                        navigateUp = { showingRelatedMangasScreen.value = false },
+                        navigator = navigator,
+                        scope = scope,
+                    )
+
+                    false -> MangaDetailContent(
+                        context = context,
+                        screenModel = screenModel,
+                        successState = successState,
+                        showRelatedMangasScreen = { showingRelatedMangasScreen.value = true },
+                        navigator = navigator,
+                        scope = scope,
+                    )
                 }
-            },
-            onTagSearch = { scope.launch { performGenreSearch(navigator, it, screenModel.source!!) } },
-            onFilterButtonClicked = screenModel::showSettingsDialog,
-            onRefresh = screenModel::fetchAllFromSource,
-            onContinueReading = { continueReading(context, screenModel.getNextUnreadChapter()) },
-            onSearch = { query, global -> scope.launch { performSearch(navigator, query, global) } },
-            onCoverClicked = screenModel::showCoverDialog,
-            onShareClicked = { shareManga(context, screenModel.manga, screenModel.source) }.takeIf { isHttpSource },
-            onDownloadActionClicked = screenModel::runDownloadAction.takeIf { !successState.source.isLocalOrStub() },
-            onEditCategoryClicked = screenModel::showChangeCategoryDialog.takeIf { successState.manga.favorite },
-            // SY -->
-            onEditInfoClicked = screenModel::showEditMangaInfoDialog,
-            // SY <--
-            onEditFetchIntervalClicked = screenModel::showSetMangaFetchIntervalDialog.takeIf {
-                successState.manga.favorite
-            },
-            onMigrateClicked = {
-                navigator.push(MigrateMangaSearchScreen(successState.manga.id))
-            }.takeIf { successState.manga.favorite },
-            onEditNotesClicked = { navigator.push(MangaNotesScreen(manga = successState.manga)) },
-            onMultiBookmarkClicked = screenModel::bookmarkChapters,
-            onMultiMarkAsReadClicked = screenModel::markChaptersRead,
-            onMarkPreviousAsReadClicked = screenModel::markPreviousChapterRead,
-            onMultiDeleteClicked = screenModel::showDeleteChapterDialog,
-            onSetDateClicked = screenModel::showSetChapterDateDialog,
-            onChapterSwipe = screenModel::chapterSwipe,
-            onChapterSelected = screenModel::toggleSelection,
-            onAllChapterSelected = screenModel::toggleAllSelection,
-            onInvertSelection = screenModel::invertSelection,
-        )
+            }
+        }
+        TachiyomiTheme {
+            CoverBasedTheme(manga = successState.manga) {
+                content()
+            }
+        }
+        // KMK <--
 
         var showScanlatorsDialog by remember { mutableStateOf(false) }
 
@@ -340,6 +326,105 @@ class MangaScreen(
             )
         }
     }
+
+    // KMK -->
+    @Composable
+    fun MangaDetailContent(
+        context: Context,
+        screenModel: MangaScreenModel,
+        successState: MangaScreenModel.State.Success,
+        showRelatedMangasScreen: () -> Unit,
+        navigator: Navigator,
+        scope: CoroutineScope,
+    ) {
+        val isHttpSource = remember { successState.source is HttpSource }
+        val haptic = LocalHapticFeedback.current
+
+        MangaScreen(
+            state = successState,
+            snackbarHostState = screenModel.snackbarHostState,
+            nextUpdate = successState.manga.expectedNextUpdate,
+            isTabletUi = isTabletUi(),
+            chapterSwipeStartAction = screenModel.chapterSwipeStartAction,
+            chapterSwipeEndAction = screenModel.chapterSwipeEndAction,
+            navigateUp = navigator::pop,
+            onChapterClicked = { openChapter(context, it) },
+            onDownloadChapter = screenModel::runChapterDownloadActions.takeIf { !successState.source.isLocalOrStub() },
+            onAddToLibraryClicked = {
+                screenModel.toggleFavorite()
+                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+            },
+            onWebViewClicked = {
+                openMangaInWebView(
+                    navigator,
+                    screenModel.manga,
+                    screenModel.source,
+                )
+            }.takeIf { isHttpSource },
+            onWebViewLongClicked = {
+                copyMangaUrl(
+                    context,
+                    screenModel.manga,
+                    screenModel.source,
+                )
+            }.takeIf { isHttpSource },
+            onTrackingClicked = {
+                if (!successState.hasLoggedInTrackers) {
+                    navigator.push(SettingsScreen(SettingsScreen.Destination.Tracking))
+                } else {
+                    screenModel.showTrackDialog()
+                }
+            },
+            onTagSearch = { scope.launch { performGenreSearch(navigator, it, screenModel.source!!) } },
+            onFilterButtonClicked = screenModel::showSettingsDialog,
+            onRefresh = screenModel::fetchAllFromSource,
+            onContinueReading = { continueReading(context, screenModel.getNextUnreadChapter()) },
+            onSearch = { query, global -> scope.launch { performSearch(navigator, query, global) } },
+            onCoverClicked = screenModel::showCoverDialog,
+            onShareClicked = { shareManga(context, screenModel.manga, screenModel.source) }.takeIf { isHttpSource },
+            onDownloadActionClicked = screenModel::runDownloadAction.takeIf { !successState.source.isLocalOrStub() },
+            onEditCategoryClicked = screenModel::showChangeCategoryDialog.takeIf { successState.manga.favorite },
+            // SY -->
+            onEditInfoClicked = screenModel::showEditMangaInfoDialog,
+            // SY <--
+            onEditFetchIntervalClicked = screenModel::showSetMangaFetchIntervalDialog.takeIf {
+                successState.manga.favorite
+            },
+            onMigrateClicked = {
+                navigator.push(MigrateMangaSearchScreen(successState.manga.id))
+            }.takeIf { successState.manga.favorite },
+            onEditNotesClicked = { navigator.push(MangaNotesScreen(manga = successState.manga)) },
+            getMangaState = { screenModel.getManga(initialManga = it) },
+            onRelatedMangasScreenClick = {
+                if (successState.isRelatedMangasFetched == null) {
+                    scope.launchIO { screenModel.fetchRelatedMangasFromSource() }
+                }
+                showRelatedMangasScreen()
+            },
+            onRelatedMangaClick = {
+                scope.launch {
+                    val manga = withIOContext { screenModel.networkToLocalManga.getLocal(it) }
+                    navigator.push(MangaScreen(manga.id, true))
+                }
+            },
+            onRelatedMangaLongClick = {
+                scope.launch {
+                    val manga = withIOContext { screenModel.networkToLocalManga.getLocal(it) }
+                    navigator.push(MangaScreen(manga.id, true))
+                }
+            },
+            onMultiBookmarkClicked = screenModel::bookmarkChapters,
+            onMultiMarkAsReadClicked = screenModel::markChaptersRead,
+            onMarkPreviousAsReadClicked = screenModel::markPreviousChapterRead,
+            onMultiDeleteClicked = screenModel::showDeleteChapterDialog,
+            onSetDateClicked = screenModel::showSetChapterDateDialog,
+            onChapterSwipe = screenModel::chapterSwipe,
+            onChapterSelected = screenModel::toggleSelection,
+            onAllChapterSelected = screenModel::toggleAllSelection,
+            onInvertSelection = screenModel::invertSelection,
+        )
+    }
+    // KMK <--
 
     private fun continueReading(context: Context, unreadChapter: Chapter?) {
         if (unreadChapter != null) openChapter(context, unreadChapter)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/MangaScreen.kt
@@ -393,7 +393,7 @@ class MangaScreen(
             getMangaState = { screenModel.getManga(initialManga = it) },
             onRelatedMangasScreenClick = {
                 if (successState.isRelatedMangasFetched == null) {
-                    scope.launchIO { screenModel.fetchRelatedMangasFromSource() }
+                    scope.launchIO { screenModel.fetchRelatedMangasFromSource(onDemand = true) }
                 }
                 showRelatedMangasScreen()
             },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/MangaScreen.kt
@@ -74,8 +74,6 @@ import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.entries.manga.model.Manga
 import tachiyomi.domain.items.chapter.model.Chapter
 import tachiyomi.presentation.core.screens.LoadingScreen
-import uy.kohesive.injekt.Injekt
-import uy.kohesive.injekt.api.get
 
 class MangaScreen(
     private val mangaId: Long,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/MangaScreenModel.kt
@@ -1393,7 +1393,7 @@ class MangaScreenModel(
                 ?.removeDuplicates(manga)
                 ?.filter { it.isVisible() }
                 ?.isLoading(isRelatedMangasFetched)
-                ?: if (isRelatedMangasFetched) emptyList() else null
+                ?: if (isRelatedMangasFetched == true) emptyList() else null
             // KMK <--
 
             val isAnySelected by lazy {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/MangaScreenModel.kt
@@ -4,8 +4,11 @@ import android.content.Context
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.produceState
 import androidx.compose.ui.util.fastAny
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
@@ -21,15 +24,18 @@ import eu.kanade.domain.entries.manga.interactor.SetExcludedScanlators
 import eu.kanade.domain.entries.manga.interactor.UpdateManga
 import eu.kanade.domain.entries.manga.model.chaptersFiltered
 import eu.kanade.domain.entries.manga.model.downloadedFilter
+import eu.kanade.domain.entries.manga.model.toDomainManga
 import eu.kanade.domain.entries.manga.model.toSManga
 import eu.kanade.domain.items.chapter.interactor.GetAvailableScanlators
 import eu.kanade.domain.items.chapter.interactor.SetReadStatus
 import eu.kanade.domain.items.chapter.interactor.SyncChaptersWithSource
+import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.domain.track.manga.interactor.AddMangaTracks
 import eu.kanade.domain.track.manga.interactor.RefreshMangaTracks
 import eu.kanade.domain.track.manga.interactor.TrackChapter
 import eu.kanade.domain.track.model.AutoTrackState
 import eu.kanade.domain.track.service.TrackPreferences
+import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.presentation.entries.DownloadAction
 import eu.kanade.presentation.entries.manga.components.ChapterDownloadAction
 import eu.kanade.presentation.util.formattedMessage
@@ -40,6 +46,9 @@ import eu.kanade.tachiyomi.data.track.EnhancedMangaTracker
 import eu.kanade.tachiyomi.data.track.TrackerManager
 import eu.kanade.tachiyomi.network.HttpException
 import eu.kanade.tachiyomi.source.MangaSource
+import eu.kanade.tachiyomi.ui.entries.manga.RelatedManga.Companion.isLoading
+import eu.kanade.tachiyomi.ui.entries.manga.RelatedManga.Companion.removeDuplicates
+import eu.kanade.tachiyomi.ui.entries.manga.RelatedManga.Companion.sorted
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.util.chapter.getNextUnread
 import eu.kanade.tachiyomi.util.removeCovers
@@ -72,7 +81,9 @@ import tachiyomi.domain.category.manga.interactor.SetMangaCategories
 import tachiyomi.domain.category.model.Category
 import tachiyomi.domain.entries.applyFilter
 import tachiyomi.domain.entries.manga.interactor.GetDuplicateLibraryManga
+import tachiyomi.domain.entries.manga.interactor.GetManga
 import tachiyomi.domain.entries.manga.interactor.GetMangaWithChapters
+import tachiyomi.domain.entries.manga.interactor.NetworkToLocalManga
 import tachiyomi.domain.entries.manga.interactor.SetCustomMangaInfo
 import tachiyomi.domain.entries.manga.interactor.SetMangaChapterFlags
 import tachiyomi.domain.entries.manga.model.CustomMangaInfo
@@ -87,6 +98,7 @@ import tachiyomi.domain.items.chapter.model.NoChaptersException
 import tachiyomi.domain.items.chapter.service.calculateChapterGap
 import tachiyomi.domain.items.chapter.service.getChapterSort
 import tachiyomi.domain.library.service.LibraryPreferences
+import tachiyomi.domain.source.manga.model.StubMangaSource
 import tachiyomi.domain.source.manga.service.MangaSourceManager
 import tachiyomi.domain.track.manga.interactor.GetMangaTracks
 import tachiyomi.i18n.MR
@@ -96,6 +108,7 @@ import tachiyomi.source.local.entries.manga.isLocal
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import kotlin.math.floor
+import androidx.compose.runtime.State as RuntimeState
 
 class MangaScreenModel(
     private val context: Context,
@@ -130,6 +143,12 @@ class MangaScreenModel(
     private val setMangaCategories: SetMangaCategories = Injekt.get(),
     private val mangaRepository: MangaRepository = Injekt.get(),
     private val filterChaptersForDownload: FilterChaptersForDownload = Injekt.get(),
+    // KMK -->
+    private val sourcePreferences: SourcePreferences = Injekt.get(),
+    private val uiPreferences: UiPreferences = Injekt.get(),
+    private val getMangaInteractor: GetManga = Injekt.get(),
+    val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
+    // KMK <--
     val snackbarHostState: SnackbarHostState = SnackbarHostState(),
 ) : StateScreenModel<MangaScreenModel.State>(State.Loading) {
 
@@ -262,6 +281,11 @@ class MangaScreenModel(
 
             // Initial loading finished
             updateSuccessState { it.copy(isRefreshingData = false) }
+
+            // KMK -->
+            // Fetch related mangas
+            fetchRelatedMangasFromSource()
+            // KMK <--
         }
     }
 
@@ -276,6 +300,82 @@ class MangaScreenModel(
             updateSuccessState { it.copy(isRefreshingData = false) }
         }
     }
+
+    // KMK -->
+
+    /**
+     * Set the fetching related mangas status.
+     * @param state
+     * - false: started & fetching
+     * - true: finished
+     */
+    private fun setRelatedMangasFetchedStatus(state: Boolean) {
+        updateSuccessState { it.copy(isRelatedMangasFetched = state) }
+    }
+
+    /**
+     * Requests a list of related mangas from the source.
+     */
+    internal suspend fun fetchRelatedMangasFromSource(onDemand: Boolean = false, onFinish: (() -> Unit)? = null) {
+        val expandRelatedMangas = uiPreferences.expandRelatedAnimes.get()
+        if (!onDemand && !expandRelatedMangas) return
+
+        // start fetching related mangas
+        setRelatedMangasFetchedStatus(false)
+
+        fun exceptionHandler(e: Throwable) {
+            logcat(LogPriority.ERROR, e)
+            val message = with(context) { e.formattedMessage }
+
+            screenModelScope.launch {
+                snackbarHostState.showSnackbar(message = message)
+            }
+        }
+        val state = successState ?: return
+        val relatedMangasEnabled = sourcePreferences.relatedAnimes.get()
+
+        try {
+            if (state.source !is StubMangaSource && relatedMangasEnabled) {
+                state.source.getRelatedMangaList(state.manga.toSManga(), { e -> exceptionHandler(e) }) { pair, _ ->
+                    /* Push found related mangas into collection */
+                    val relatedManga = RelatedManga.Success.fromPair(pair) { mangaList ->
+                        mangaList.map {
+                            it.toDomainManga(state.source.id)
+                        }
+                    }
+
+                    updateSuccessState { successState ->
+                        val relatedMangaCollection =
+                            successState.relatedMangaCollection
+                                ?.toMutableList()
+                                ?.apply { add(relatedManga) }
+                                ?: listOf(relatedManga)
+                        successState.copy(relatedMangaCollection = relatedMangaCollection)
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            exceptionHandler(e)
+        } finally {
+            if (onFinish != null) {
+                onFinish()
+            } else {
+                setRelatedMangasFetchedStatus(true)
+            }
+        }
+    }
+
+    @Composable
+    fun getManga(initialManga: Manga): RuntimeState<Manga> {
+        return produceState(initialValue = initialManga) {
+            getMangaInteractor.subscribe(initialManga.url, initialManga.source)
+                .flowWithLifecycle(lifecycle)
+                .collectLatest { manga ->
+                    value = manga ?: initialManga
+                }
+        }
+    }
+    // KMK <--
 
     // Manga info - start
 
@@ -1279,10 +1379,22 @@ class MangaScreenModel(
             val isRefreshingData: Boolean = false,
             val dialog: Dialog? = null,
             val hasPromptedToAddBefore: Boolean = false,
+            // KMK -->
+            val isRelatedMangasFetched: Boolean? = null,
+            val relatedMangaCollection: List<RelatedManga>? = null,
+            // KMK <--
         ) : State {
             val processedChapters by lazy {
                 chapters.applyFilters(manga).toList()
             }
+
+            // KMK -->
+            val relatedMangasSorted = relatedMangaCollection
+                ?.sorted(manga)
+                ?.removeDuplicates(manga)
+                ?.filter { it.isVisible() }
+                ?.isLoading(isRelatedMangasFetched)
+            // KMK <--
 
             val isAnySelected by lazy {
                 chapters.fastAny { it.selected }
@@ -1367,3 +1479,71 @@ sealed class ChapterList {
         val isDownloaded = downloadState == MangaDownload.State.DOWNLOADED
     }
 }
+
+// KMK -->
+sealed interface RelatedManga {
+    data object Loading : RelatedManga
+
+    data class Success(
+        val keyword: String,
+        val mangaList: List<Manga>,
+    ) : RelatedManga {
+        val isEmpty: Boolean
+            get() = mangaList.isEmpty()
+
+        companion object {
+            suspend fun fromPair(
+                pair: Pair<String, List<eu.kanade.tachiyomi.source.model.SManga>>,
+                toManga: suspend (mangaList: List<eu.kanade.tachiyomi.source.model.SManga>) -> List<Manga>,
+            ) = Success(pair.first, toManga(pair.second))
+        }
+    }
+
+    fun isVisible(): Boolean {
+        return this is Loading || (this is Success && !this.isEmpty)
+    }
+
+    companion object {
+        internal fun List<RelatedManga>.sorted(manga: Manga): List<RelatedManga> {
+            val success = filterIsInstance<Success>()
+            val loading = filterIsInstance<Loading>()
+            val title = manga.title.lowercase()
+            val ogTitle = manga.ogTitle.lowercase()
+            return success.filter { it.keyword.isEmpty() } +
+                success.filter { it.keyword.lowercase() == title } +
+                success.filter { it.keyword.lowercase() == ogTitle && ogTitle != title } +
+                success.filter { it.keyword.isNotEmpty() && it.keyword.lowercase() !in listOf(title, ogTitle) }
+                    .sortedByDescending { it.keyword.length }
+                    .sortedBy { it.mangaList.size } +
+                loading
+        }
+
+        internal fun List<RelatedManga>.removeDuplicates(manga: Manga): List<RelatedManga> {
+            val mangaHashes = HashSet<Int>().apply { add(manga.url.hashCode()) }
+
+            return map { relatedManga ->
+                if (relatedManga is Success) {
+                    val stripedList = relatedManga.mangaList.mapNotNull {
+                        if (!mangaHashes.contains(it.url.hashCode())) {
+                            mangaHashes.add(it.url.hashCode())
+                            it
+                        } else {
+                            null
+                        }
+                    }
+                    Success(
+                        relatedManga.keyword,
+                        stripedList,
+                    )
+                } else {
+                    relatedManga
+                }
+            }
+        }
+
+        internal fun List<RelatedManga>.isLoading(isRelatedMangaFetched: Boolean?): List<RelatedManga> {
+            return if (isRelatedMangaFetched == false) this + listOf(Loading) else this
+        }
+    }
+}
+// KMK <--

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/MangaScreenModel.kt
@@ -1393,6 +1393,7 @@ class MangaScreenModel(
                 ?.removeDuplicates(manga)
                 ?.filter { it.isVisible() }
                 ?.isLoading(isRelatedMangasFetched)
+                ?: if (isRelatedMangasFetched) emptyList() else null
             // KMK <--
 
             val isAnySelected by lazy {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/MangaScreenModel.kt
@@ -7,7 +7,6 @@ import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.produceState
 import androidx.compose.ui.util.fastAny
 import androidx.lifecycle.Lifecycle

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/RelatedMangasScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/RelatedMangasScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.util.fastAny
 import cafe.adriel.voyager.navigator.Navigator
 import eu.kanade.core.preference.asState
 import eu.kanade.domain.source.service.SourcePreferences
@@ -35,7 +34,6 @@ import kotlinx.coroutines.CoroutineScope
 import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.domain.entries.manga.model.Manga
 import tachiyomi.domain.entries.manga.model.MangaCover
-import tachiyomi.domain.library.model.LibraryDisplayMode
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.tail.TLMR

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/RelatedMangasScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/RelatedMangasScreen.kt
@@ -1,0 +1,229 @@
+package eu.kanade.tachiyomi.ui.entries.manga
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.fastAny
+import cafe.adriel.voyager.navigator.Navigator
+import eu.kanade.core.preference.asState
+import eu.kanade.domain.source.service.SourcePreferences
+import eu.kanade.presentation.browse.InLibraryBadge
+import eu.kanade.presentation.browse.anime.RelatedAnimeTitle
+import eu.kanade.presentation.browse.anime.RelatedAnimesLoadingItem
+import eu.kanade.presentation.browse.anime.components.BrowseSourceSimpleToolbar
+import eu.kanade.presentation.library.components.CommonEntryItemDefaults
+import eu.kanade.presentation.library.components.EntryComfortableGridItem
+import eu.kanade.tachiyomi.ui.browse.manga.source.browse.BrowseMangaSourceScreen
+import eu.kanade.tachiyomi.ui.browse.manga.source.globalsearch.GlobalMangaSearchScreen
+import kotlinx.coroutines.CoroutineScope
+import tachiyomi.core.common.util.lang.launchIO
+import tachiyomi.domain.entries.manga.model.Manga
+import tachiyomi.domain.entries.manga.model.MangaCover
+import tachiyomi.domain.library.model.LibraryDisplayMode
+import tachiyomi.domain.library.service.LibraryPreferences
+import tachiyomi.i18n.MR
+import tachiyomi.i18n.tail.TLMR
+import tachiyomi.presentation.core.components.FastScrollLazyVerticalGrid
+import tachiyomi.presentation.core.components.material.Scaffold
+import tachiyomi.presentation.core.components.material.padding
+import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.presentation.core.screens.EmptyScreen
+import tachiyomi.presentation.core.screens.LoadingScreen
+import tachiyomi.presentation.core.util.plus
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+@Composable
+fun RelatedMangasScreen(
+    screenModel: MangaScreenModel,
+    navigateUp: () -> Unit,
+    navigator: Navigator,
+    scope: CoroutineScope,
+    successState: MangaScreenModel.State.Success,
+) {
+    val sourcePreferences: SourcePreferences = Injekt.get()
+    var displayMode by sourcePreferences.sourceDisplayMode.asState(scope)
+
+    val haptic = LocalHapticFeedback.current
+
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    Scaffold(
+        topBar = { scrollBehavior ->
+            BrowseSourceSimpleToolbar(
+                navigateUp = navigateUp,
+                title = successState.manga.title,
+                displayMode = displayMode,
+                onDisplayModeChange = { displayMode = it },
+                scrollBehavior = scrollBehavior,
+                toggleSelectionMode = {},
+                isRunning = false,
+            )
+        },
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
+    ) { paddingValues ->
+        RelatedMangasContent(
+            relatedMangas = successState.relatedMangasSorted,
+            getMangaState = { manga -> screenModel.getManga(initialManga = manga) },
+            columns = getColumnsPreference(LocalConfiguration.current.orientation),
+            contentPadding = paddingValues,
+            onMangaClick = {
+                scope.launchIO {
+                    val manga = screenModel.networkToLocalManga.getLocal(it)
+                    navigator.push(MangaScreen(manga.id, true))
+                }
+            },
+            onMangaLongClick = {
+                scope.launchIO {
+                    val manga = screenModel.networkToLocalManga.getLocal(it)
+                    navigator.push(MangaScreen(manga.id, true))
+                }
+            },
+            onKeywordClick = { query ->
+                navigator.push(BrowseMangaSourceScreen(successState.source.id, query))
+            },
+            onKeywordLongClick = { query ->
+                navigator.push(GlobalMangaSearchScreen(query))
+            },
+            selection = emptyList(),
+        )
+    }
+}
+
+@Composable
+fun RelatedMangasContent(
+    relatedMangas: List<RelatedManga>?,
+    getMangaState: @Composable (Manga) -> State<Manga>,
+    columns: GridCells,
+    contentPadding: PaddingValues,
+    onMangaClick: (Manga) -> Unit,
+    onMangaLongClick: (Manga) -> Unit,
+    onKeywordClick: (String) -> Unit,
+    onKeywordLongClick: (String) -> Unit,
+    selection: List<Manga>,
+) {
+    if (relatedMangas == null) {
+        LoadingScreen(
+            modifier = Modifier.then(Modifier),
+        )
+        return
+    }
+
+    if (relatedMangas.isEmpty()) {
+        EmptyScreen(
+            message = stringResource(MR.strings.no_results_found),
+        )
+        return
+    }
+
+    FastScrollLazyVerticalGrid(
+        columns = columns,
+        contentPadding = contentPadding + PaddingValues(horizontal = MaterialTheme.padding.small),
+        topContentPadding = contentPadding.calculateTopPadding(),
+        verticalArrangement = Arrangement.spacedBy(CommonEntryItemDefaults.GridVerticalSpacer),
+        horizontalArrangement = Arrangement.spacedBy(CommonEntryItemDefaults.GridHorizontalSpacer),
+    ) {
+        relatedMangas.forEach { related ->
+            val isLoading = related is RelatedManga.Loading
+            if (isLoading) {
+                item(
+                    key = "${related.hashCode()}#header",
+                    span = { GridItemSpan(maxLineSpan) },
+                ) {
+                    RelatedAnimeTitle(
+                        title = stringResource(MR.strings.loading),
+                        subtitle = null,
+                        onClick = {},
+                        onLongClick = null,
+                        modifier = Modifier.background(MaterialTheme.colorScheme.background),
+                    )
+                }
+                item(
+                    key = "${related.hashCode()}#content",
+                    span = { GridItemSpan(maxLineSpan) },
+                ) { RelatedAnimesLoadingItem() }
+            } else {
+                val relatedManga = related as RelatedManga.Success
+                item(
+                    key = "${related.hashCode()}#divider",
+                    span = { GridItemSpan(maxLineSpan) },
+                ) { HorizontalDivider() }
+                item(
+                    key = "${related.hashCode()}#header",
+                    span = { GridItemSpan(maxLineSpan) },
+                ) {
+                    RelatedAnimeTitle(
+                        title = if (relatedManga.keyword.isNotBlank()) {
+                            stringResource(TLMR.strings.related_mangas_more)
+                        } else {
+                            stringResource(TLMR.strings.related_mangas_website_suggestions)
+                        },
+                        showArrow = relatedManga.keyword.isNotBlank(),
+                        subtitle = null,
+                        onClick = {
+                            if (relatedManga.keyword.isNotBlank()) onKeywordClick(relatedManga.keyword)
+                        },
+                        onLongClick = {
+                            if (relatedManga.keyword.isNotBlank()) onKeywordLongClick(relatedManga.keyword)
+                        },
+                        modifier = Modifier.background(MaterialTheme.colorScheme.background),
+                    )
+                }
+                items(
+                    key = { "related-manga-${relatedManga.mangaList[it].url.hashCode()}" },
+                    count = relatedManga.mangaList.size,
+                ) { index ->
+                    val manga by getMangaState(relatedManga.mangaList[index])
+                    EntryComfortableGridItem(
+                        title = manga.title,
+                        coverData = MangaCover(
+                            mangaId = manga.id,
+                            sourceId = manga.source,
+                            isMangaFavorite = manga.favorite,
+                            url = manga.thumbnailUrl,
+                            lastModified = manga.coverLastModified,
+                        ),
+                        coverAlpha = if (manga.favorite) {
+                            CommonEntryItemDefaults.BrowseFavoriteCoverAlpha
+                        } else {
+                            1f
+                        },
+                        coverBadgeStart = {
+                            InLibraryBadge(enabled = manga.favorite)
+                        },
+                        onLongClick = { onMangaLongClick(manga) },
+                        onClick = { onMangaClick(manga) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun getColumnsPreference(orientation: Int): GridCells {
+    val libraryPreferences: LibraryPreferences = Injekt.get()
+
+    val isLandscape = orientation == Configuration.ORIENTATION_LANDSCAPE
+    val columns = if (isLandscape) {
+        libraryPreferences.mangaLandscapeColumns
+    } else {
+        libraryPreferences.mangaPortraitColumns
+    }.get()
+    return if (columns == 0) GridCells.Adaptive(128.dp) else GridCells.Fixed(columns)
+}

--- a/domain/src/main/java/tachiyomi/domain/entries/manga/interactor/NetworkToLocalManga.kt
+++ b/domain/src/main/java/tachiyomi/domain/entries/manga/interactor/NetworkToLocalManga.kt
@@ -36,6 +36,14 @@ class NetworkToLocalManga(
         }
     }
 
+    // KMK -->
+    suspend fun getLocal(manga: Manga): Manga = if (manga.id <= 0) {
+        await(manga)
+    } else {
+        manga
+    }
+    // KMK <--
+
     private suspend fun getManga(url: String, sourceId: Long): Manga? {
         return mangaRepository.getMangaByUrlAndSourceId(url, sourceId)
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ androidx-glance = "1.1.1"
 androidx-interpolator = "1.0.0"
 androidx-lifecycle = "2.10.0"
 androidx-paging = "3.4.2"
+androidx-palette = "1.0.0"
 androidx-preference = "1.2.1"
 androidx-profileInstaller = "1.4.1"
 androidx-recyclerView = "1.4.0"
@@ -106,6 +107,7 @@ androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", 
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
 androidx-paging-compose = { module = "androidx.paging:paging-compose", version.ref = "androidx-paging" }
 androidx-paging-runtime = { module = "androidx.paging:paging-runtime", version.ref = "androidx-paging" }
+androidx-palette = { module = "androidx.palette:palette-ktx", version.ref = "androidx-palette" }
 androidx-preference = { module = "androidx.preference:preference-ktx", version.ref = "androidx-preference" }
 androidx-profileInstaller = { module = "androidx.profileinstaller:profileinstaller", version.ref = "androidx-profileInstaller" }
 androidx-recyclerView = { module = "androidx.recyclerview:recyclerview", version.ref = "androidx-recyclerView" }

--- a/i18n-tail/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-tail/src/commonMain/moko-resources/base/strings.xml
@@ -421,4 +421,27 @@
     <string name="pref_tracking_sync_enhanced">Sync progress from enhanced trackers</string>
     <string name="pref_smart_sync_tracker">Smart sync seasons</string>
     <string name="pref_smart_sync_tracker_summary">Skip completed items and stop at entry in progress</string>
+
+    <!-- Cover-based theme -->
+    <string name="pref_anime_info">Entry Info Theme</string>
+    <string name="pref_theme_cover_based">Cover-based theme</string>
+    <string name="pref_theme_cover_based_style">Cover-based theme style</string>
+    <string name="pref_custom_theme_style">Custom theme style</string>
+    <string name="pref_theme_cover_based_style_tonalspot">Tonal Spot</string>
+    <string name="pref_theme_cover_based_style_neutral">Neutral</string>
+    <string name="pref_theme_cover_based_style_vibrant">Vibrant</string>
+    <string name="pref_theme_cover_based_style_expressive">Expressive</string>
+    <string name="pref_theme_cover_based_style_rainbow">Rainbow</string>
+    <string name="pref_theme_cover_based_style_fruitsalad">Fruit Salad</string>
+    <string name="pref_theme_cover_based_style_monochrome">Monochrome</string>
+    <string name="pref_theme_cover_based_style_fidelity">Fidelity</string>
+    <string name="pref_theme_cover_based_style_content">Content</string>
+
+    <!-- Panoramic cover -->
+    <string name="pref_panorama_cover">Panoramic cover</string>
+    <string name="pref_panorama_cover_summary">Show wide covers in full without cropping</string>
+
+    <!-- Top align cover -->
+    <string name="pref_top_align_cover">Align cover to top</string>
+    <string name="pref_top_align_cover_summary">Align the cover image to the top instead of center</string>
 </resources>

--- a/i18n-tail/src/commonMain/moko-resources/es/strings.xml
+++ b/i18n-tail/src/commonMain/moko-resources/es/strings.xml
@@ -306,9 +306,9 @@
   <string name="put_related_animes_in_overflow_summary">Ponga el botón Sugerencias en el menú de desbordamiento en lugar de en la página de entrada</string>
   <string name="pref_show_home_on_related_animes">Inicio desde sugerencias</string>
   <string name="pref_show_home_on_related_animes_summary">Muestra un icono mientras se navega por las Sugerencias para volver directamente a Inicio</string>
-    <string name="pref_show_cast">Show Cast</string>
-    <string name="pref_show_cast_summary">Show cast information on anime details page</string>
-    <string name="pref_source_related_animes">Sugerencias</string>
+  <string name="pref_show_cast">Mostrar reparto</string>
+  <string name="pref_show_cast_summary">Mostrar información del reparto en la página de detalles del anime</string>
+  <string name="pref_source_related_animes">Sugerencias</string>
   <string name="pref_source_related_animes_summary">Mostrar sugerencias del sitio de origen mientras se ve la entrada</string>
   <string name="pref_source_navigation">Reemplazar el último botón</string>
   <string name="pref_source_navigation_summery">Reemplaza el último botón con una vista de navegación personalizada que incluye tanto la última como la última navegación</string>
@@ -316,10 +316,10 @@
   <string name="pref_sync_api_key_summ">Introduzca la clave API para sincronizar su biblioteca</string>
   <string name="login_error">Error de inicio de sesión</string>
   <string name="save">Guardar</string>
-    <string name="pref_doh_custom_url">URL de DoH personalizada</string>
-    <string name="pref_doh_custom_url_summary">Ejemplo: https://dns.example/dns-query</string>
-    <string name="error_doh_custom_invalid">URL de DoH no válida</string>
-    <string name="error_doh_custom_must_use_https">El DoH personalizado debe usar https</string>
+  <string name="pref_doh_custom_url">URL de DoH personalizada</string>
+  <string name="pref_doh_custom_url_summary">Ejemplo: https://dns.example/dns-query</string>
+  <string name="error_doh_custom_invalid">URL de DoH no válida</string>
+  <string name="error_doh_custom_must_use_https">El DoH personalizado debe usar https</string>
     <string name="pref_doh_custom_bootstrap">Hosts de arranque de DoH personalizados</string>
     <string name="pref_doh_custom_bootstrap_summary">IP separadas por comas (opcional). Ejemplo: 1.1.1.1,8.8.8.8</string>
     <string name="error_doh_custom_bootstrap_invalid">Host de arranque no válido: %1$s</string>
@@ -343,15 +343,30 @@
     <string name="network_stream_header_error">El encabezado en la línea %1$d debe usar el formato "Nombre: Valor"</string>
     <string name="network_stream_play">Reproducir transmisión</string>
     <string name="network_stream_reset">Limpiar campos</string>
-
     <string name="player_sheets_subtitles_ass_no">No</string>
     <string name="player_sheets_subtitles_ass_yes">Sí</string>
     <string name="player_sheets_subtitles_ass_scale">Escalar</string>
     <string name="player_sheets_subtitles_ass_force">Forzar</string>
     <string name="player_sheets_subtitles_ass_strip">Eliminar</string>
-
     <string name="pref_tracking_sync_enhanced">Sincronizar progreso desde rastreadores mejorados</string>
     <string name="pref_smart_sync_tracker">Sincronización inteligente de temporadas</string>
     <string name="pref_smart_sync_tracker_summary">Omite elementos completados y se detiene en el elemento en curso</string>
+    <string name="pref_anime_info">Información de la entrada</string>
+    <string name="pref_theme_cover_based">Tema basado en portada</string>
+    <string name="pref_theme_cover_based_style">Estilo del tema basado en portada</string>
+    <string name="pref_custom_theme_style">Estilo de tema personalizado</string>
+    <string name="pref_theme_cover_based_style_tonalspot">Tono destacado</string>
+    <string name="pref_theme_cover_based_style_neutral">Neutro</string>
+    <string name="pref_theme_cover_based_style_vibrant">Vibrante</string>
+    <string name="pref_theme_cover_based_style_expressive">Expresivo</string>
+    <string name="pref_theme_cover_based_style_rainbow">Arcoíris</string>
+    <string name="pref_theme_cover_based_style_fruitsalad">Ensalada de frutas</string>
+    <string name="pref_theme_cover_based_style_monochrome">Monocromático</string>
+    <string name="pref_theme_cover_based_style_fidelity">Fidelidad</string>
+    <string name="pref_theme_cover_based_style_content">Contenido</string>
+    <string name="pref_panorama_cover">Portada panorámica</string>
+    <string name="pref_panorama_cover_summary">Mostrar portadas anchas completas sin recortarlas</string>
+    <string name="pref_top_align_cover">Alinear portada arriba</string>
+    <string name="pref_top_align_cover_summary">Alinear la imagen de portada en la parte superior en lugar de centrada</string>
 
 </resources>

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/CatalogueSource.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/CatalogueSource.kt
@@ -2,8 +2,15 @@ package eu.kanade.tachiyomi.source
 
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.SManga
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
+import logcat.LogPriority
 import rx.Observable
 import tachiyomi.core.common.util.lang.awaitSingle
+import tachiyomi.core.common.util.system.logcat
 
 interface CatalogueSource : MangaSource {
 
@@ -77,4 +84,136 @@ interface CatalogueSource : MangaSource {
     )
     fun fetchLatestUpdates(page: Int): Observable<MangasPage> =
         throw IllegalStateException("Not used")
+
+    // KMK -->
+
+    /**
+     * Whether parsing related mangas in manga page or extension provide custom related mangas request.
+     * @default false
+     * @since komikku/extensions-lib 1.6
+     */
+    val supportsRelatedMangas: Boolean get() = false
+
+    /**
+     * Extensions doesn't want to use App's [getRelatedMangaListBySearch].
+     * @default false
+     * @since komikku/extensions-lib 1.6
+     */
+    val disableRelatedMangasBySearch: Boolean get() = false
+
+    /**
+     * Disable showing any related mangas.
+     * @default false
+     * @since komikku/extensions-lib 1.6
+     */
+    val disableRelatedMangas: Boolean get() = false
+
+    /**
+     * Get all the available related mangas for a manga.
+     * Normally it's not needed to override this method.
+     *
+     * @since komikku/extensions-lib 1.6
+     * @param manga the current manga to get related mangas.
+     * @return a list of <keyword, related mangas>
+     * @throws UnsupportedOperationException if a source doesn't support related mangas.
+     */
+    override suspend fun getRelatedMangaList(
+        manga: SManga,
+        exceptionHandler: (Throwable) -> Unit,
+        pushResults: suspend (relatedManga: Pair<String, List<SManga>>, completed: Boolean) -> Unit,
+    ) {
+        val handler = CoroutineExceptionHandler { _, e -> exceptionHandler(e) }
+        if (!disableRelatedMangas) {
+            supervisorScope {
+                if (supportsRelatedMangas) launch(handler) { getRelatedMangaListByExtension(manga, pushResults) }
+                if (!disableRelatedMangasBySearch) launch(handler) { getRelatedMangaListBySearch(manga, pushResults) }
+            }
+        }
+    }
+
+    /**
+     * Get related mangas provided by extension
+     *
+     * @return a list of <keyword, related mangas>
+     * @since komikku/extensions-lib 1.6
+     */
+    suspend fun getRelatedMangaListByExtension(
+        manga: SManga,
+        pushResults: suspend (relatedManga: Pair<String, List<SManga>>, completed: Boolean) -> Unit,
+    ) {
+        runCatching { fetchRelatedMangaList(manga) }
+            .onSuccess { if (it.isNotEmpty()) pushResults(Pair("", it), false) }
+            .onFailure { e ->
+                logcat(LogPriority.ERROR, e) { "## getRelatedMangaListByExtension: $e" }
+            }
+    }
+
+    /**
+     * Fetch related mangas for a manga from source/site.
+     *
+     * @since komikku/extensions-lib 1.6
+     * @param manga the current manga to get related mangas.
+     * @return the related mangas for the current manga.
+     * @throws UnsupportedOperationException if a source doesn't support related mangas.
+     */
+    suspend fun fetchRelatedMangaList(manga: SManga): List<SManga> =
+        throw UnsupportedOperationException("Unsupported!")
+
+    /**
+     * Split & strip manga's title into separate searchable keywords.
+     * Used for searching related mangas.
+     *
+     * @since komikku/extensions-lib 1.6
+     * @return List of keywords.
+     */
+    fun String.stripKeywordForRelatedMangas(): List<String> {
+        val regexWhitespace = Regex("\\s+")
+        val regexSpecialCharacters =
+            Regex(
+                "([!~#$%^&*+_|/\\\\,?:;'\u201c\u201d\u2018\u2019\"<>(){}\\[\\]\u3002\u30fb\uff5e\uff1a\u2014\uff01\uff1f\u3001\u2015\u00ab\u00bb\u300a\u300b\u3018\u3019\u3010\u3011\u300c\u300d\uff5c]|\\s-|-\\s|\\s\\.|\\.\\s)",
+            )
+        val regexNumberOnly = Regex("^\\d+$")
+
+        return replace(regexSpecialCharacters, " ")
+            .split(regexWhitespace)
+            .map {
+                it.replace(regexNumberOnly, "")
+                    .lowercase()
+            }
+            .filter { it.length > 1 }
+    }
+
+    /**
+     * Get related mangas by searching for each keywords from manga's title.
+     *
+     * @return a list of <keyword, related mangas>
+     * @since komikku/extensions-lib 1.6
+     */
+    suspend fun getRelatedMangaListBySearch(
+        manga: SManga,
+        pushResults: suspend (relatedManga: Pair<String, List<SManga>>, completed: Boolean) -> Unit,
+    ) {
+        val words = HashSet<String>()
+        words.add(manga.title)
+        if (manga.title.lowercase() != manga.title.lowercase()) words.add(manga.title)
+        manga.title.stripKeywordForRelatedMangas()
+            .filterNot { word -> words.any { it.lowercase() == word } }
+            .onEach { words.add(it) }
+        if (words.isEmpty()) return
+
+        coroutineScope {
+            words.map { keyword ->
+                launch {
+                    runCatching {
+                        getSearchManga(1, keyword, FilterList()).mangas
+                    }
+                        .onSuccess { if (it.isNotEmpty()) pushResults(Pair(keyword, it), false) }
+                        .onFailure { e ->
+                            logcat(LogPriority.ERROR, e) { "## getRelatedMangaListBySearch: $e" }
+                        }
+                }
+            }
+        }
+    }
+    // KMK <--
 }

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/CatalogueSource.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/CatalogueSource.kt
@@ -195,7 +195,8 @@ interface CatalogueSource : MangaSource {
     ) {
         val words = HashSet<String>()
         words.add(manga.title)
-        if (manga.title.lowercase() != manga.title.lowercase()) words.add(manga.title)
+        val lowercaseTitle = manga.title.lowercase()
+        if (manga.title != lowercaseTitle) words.add(lowercaseTitle)
         manga.title.stripKeywordForRelatedMangas()
             .filterNot { word -> words.any { it.lowercase() == word } }
             .onEach { words.add(it) }

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/MangaSource.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/MangaSource.kt
@@ -81,4 +81,20 @@ interface MangaSource {
     )
     fun fetchPageList(chapter: SChapter): Observable<List<Page>> =
         throw IllegalStateException("Not used")
+
+    // KMK -->
+
+    /**
+     * Get all the available related mangas for a manga.
+     *
+     * @since komikku/extensions-lib 1.6
+     * @param manga the current manga to get related mangas.
+     * @return a list of <keyword, related mangas>
+     */
+    suspend fun getRelatedMangaList(
+        manga: SManga,
+        exceptionHandler: (Throwable) -> Unit,
+        pushResults: suspend (relatedManga: Pair<String, List<SManga>>, completed: Boolean) -> Unit,
+    ): Unit = throw UnsupportedOperationException()
+    // KMK <--
 }

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
@@ -484,7 +484,7 @@ abstract class HttpSource : CatalogueSource {
         async {
             client.newCall(relatedMangaListRequest(manga))
                 .execute()
-                .let { response ->
+                .use { response ->
                     relatedMangaListParse(response)
                 }
         }.await()

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
@@ -11,6 +11,8 @@ import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import okhttp3.Headers
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -458,4 +460,54 @@ abstract class HttpSource : CatalogueSource {
      * Returns the list of filters for the source.
      */
     override fun getFilterList() = FilterList()
+
+    // KMK -->
+
+    /**
+     * Whether parsing related mangas in manga page or extension provide custom related mangas request.
+     *
+     * @default true
+     * @since komikku/extensions-lib 1.6
+     */
+    override val supportsRelatedMangas: Boolean get() = true
+
+    /**
+     * Fetch related mangas for a manga from source/site.
+     * Normally it's not needed to override this method.
+     *
+     * @since komikku/extensions-lib 1.6
+     * @param manga the current manga to get related mangas.
+     * @return the related mangas for the current manga.
+     * @throws UnsupportedOperationException if a source doesn't support related mangas.
+     */
+    override suspend fun fetchRelatedMangaList(manga: SManga): List<SManga> = coroutineScope {
+        async {
+            client.newCall(relatedMangaListRequest(manga))
+                .execute()
+                .let { response ->
+                    relatedMangaListParse(response)
+                }
+        }.await()
+    }
+
+    /**
+     * Returns the request for get related manga list. Override only if it's needed to override
+     * the url, send different headers or request method like POST.
+     * Normally it's not needed to override this method.
+     *
+     * @since komikku/extensions-lib 1.6
+     * @param manga the manga to look for related mangas.
+     */
+    protected open fun relatedMangaListRequest(manga: SManga): Request {
+        return mangaDetailsRequest(manga)
+    }
+
+    /**
+     * Parses the response from the site and returns a list of related mangas.
+     *
+     * @since komikku/extensions-lib 1.6
+     * @param response the response from the site.
+     */
+    protected open fun relatedMangaListParse(response: Response): List<SManga> = popularMangaParse(response).mangas
+    // KMK <--
 }

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/ParsedHttpSource.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/ParsedHttpSource.kt
@@ -198,4 +198,34 @@ abstract class ParsedHttpSource : HttpSource() {
      * @param document the parsed document.
      */
     protected abstract fun imageUrlParse(document: Document): String
+
+    // KMK -->
+
+    /**
+     * Parses the response from the site and returns a list of related mangas.
+     * Normally it's not needed to override this method.
+     *
+     * @since komikku/extensions-lib 1.6
+     * @param response the response from the site.
+     */
+    override fun relatedMangaListParse(response: Response): List<SManga> {
+        return response.asJsoup()
+            .select(relatedMangaListSelector()).map { relatedMangaFromElement(it) }
+    }
+
+    /**
+     * Returns the Jsoup selector that returns a list of [Element] corresponding to each related manga.
+     *
+     * @since komikku/extensions-lib 1.6
+     */
+    protected open fun relatedMangaListSelector(): String = popularMangaSelector()
+
+    /**
+     * Returns a manga from the given element.
+     *
+     * @since komikku/extensions-lib 1.6
+     * @param element an element obtained from [relatedMangaListSelector].
+     */
+    protected open fun relatedMangaFromElement(element: Element): SManga = popularMangaFromElement(element)
+    // KMK <--
 }


### PR DESCRIPTION
- Implemented `getLocal` method in `NetworkToLocalManga` for fetching local manga.
- Added support for `androidx.palette` library in `libs.versions.toml`.
- Introduced new strings for cover-based theme preferences in `strings.xml` and Spanish localization.
- Enhanced `CatalogueSource` and `MangaSource` interfaces with related mangas functionality.
- Updated `HttpSource` and `ParsedHttpSource` to handle fetching and parsing related mangas.
- Created `RelatedMangasRow` and `RelatedMangaCardRow` composables for displaying related mangas.
- Developed `CoverBasedTheme` composable to apply theme based on manga/anime cover.
- Added `RelatedMangasScreen` for displaying related mangas in a grid layout.

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
