### PR TITLE
A fix for Extension update notifications sending you to the wrong tab in Browse. Untested

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseTab.kt
@@ -67,11 +67,11 @@ data object BrowseTab : Tab {
     private val switchToTabNumberChannel = Channel<Int>(1, BufferOverflow.DROP_OLDEST)
 
     fun showExtension() {
-        switchToTabNumberChannel.trySend(4) // Manga extensions: tab no. 4
+        switchToTabNumberChannel.trySend(3) // Manga extensions in hideFeedTab layout
     }
 
     fun showAnimeExtension() {
-        switchToTabNumberChannel.trySend(3) // Anime extensions: tab no. 3
+        switchToTabNumberChannel.trySend(2) // Anime extensions in hideFeedTab layout
     }
 
     @Composable
@@ -152,9 +152,12 @@ data object BrowseTab : Tab {
             // KMK <--
             scrollable = true,
         )
-        LaunchedEffect(Unit) {
+        LaunchedEffect(hideFeedTab, feedTabInFront) {
+            val tabOffset = if (hideFeedTab) 0 else 1
             switchToTabNumberChannel.receiveAsFlow()
-                .collectLatest { state.scrollToPage(it) }
+                .collectLatest { tab ->
+                    state.scrollToPage(tab + tabOffset)
+                }
         }
 
         LaunchedEffect(Unit) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseTab.kt
@@ -67,11 +67,11 @@ data object BrowseTab : Tab {
     private val switchToTabNumberChannel = Channel<Int>(1, BufferOverflow.DROP_OLDEST)
 
     fun showExtension() {
-        switchToTabNumberChannel.trySend(3) // Manga extensions: tab no. 3
+        switchToTabNumberChannel.trySend(4) // Manga extensions: tab no. 4
     }
 
     fun showAnimeExtension() {
-        switchToTabNumberChannel.trySend(2) // Anime extensions: tab no. 2
+        switchToTabNumberChannel.trySend(3) // Anime extensions: tab no. 3
     }
 
     @Composable

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseTab.kt
@@ -64,14 +64,19 @@ data object BrowseTab : Tab {
         navigator.push(GlobalAnimeSearchScreen())
     }
 
-    private val switchToTabNumberChannel = Channel<Int>(1, BufferOverflow.DROP_OLDEST)
+    private enum class ExtensionTabTarget {
+        ANIME,
+        MANGA,
+    }
+
+    private val switchToExtensionTabChannel = Channel<ExtensionTabTarget>(1, BufferOverflow.DROP_OLDEST)
 
     fun showExtension() {
-        switchToTabNumberChannel.trySend(3) // Manga extensions in hideFeedTab layout
+        switchToExtensionTabChannel.trySend(ExtensionTabTarget.MANGA)
     }
 
     fun showAnimeExtension() {
-        switchToTabNumberChannel.trySend(2) // Anime extensions in hideFeedTab layout
+        switchToExtensionTabChannel.trySend(ExtensionTabTarget.ANIME)
     }
 
     @Composable
@@ -90,6 +95,9 @@ data object BrowseTab : Tab {
         val animeExtensionsScreenModel = rememberScreenModel { AnimeExtensionsScreenModel() }
         val animeExtensionsState by animeExtensionsScreenModel.state.collectAsState()
 
+        val animeExtensionsTabContent = animeExtensionsTab(animeExtensionsScreenModel)
+        val mangaExtensionsTabContent = mangaExtensionsTab(mangaExtensionsScreenModel)
+
         // KMK -->
         val feedScreenModel = rememberScreenModel { FeedScreenModel() }
         // KMK <--
@@ -99,8 +107,8 @@ data object BrowseTab : Tab {
                 persistentListOf(
                     animeSourcesTab(),
                     mangaSourcesTab(),
-                    animeExtensionsTab(animeExtensionsScreenModel),
-                    mangaExtensionsTab(mangaExtensionsScreenModel),
+                    animeExtensionsTabContent,
+                    mangaExtensionsTabContent,
                     migrateAnimeSourceTab(),
                     migrateMangaSourceTab(),
                 )
@@ -114,8 +122,8 @@ data object BrowseTab : Tab {
                     ),
                     animeSourcesTab(),
                     mangaSourcesTab(),
-                    animeExtensionsTab(animeExtensionsScreenModel),
-                    mangaExtensionsTab(mangaExtensionsScreenModel),
+                    animeExtensionsTabContent,
+                    mangaExtensionsTabContent,
                     migrateAnimeSourceTab(),
                     migrateMangaSourceTab(),
                 )
@@ -129,12 +137,19 @@ data object BrowseTab : Tab {
                         feedScreenModel,
                         // KMK <--
                     ),
-                    animeExtensionsTab(animeExtensionsScreenModel),
-                    mangaExtensionsTab(mangaExtensionsScreenModel),
+                    animeExtensionsTabContent,
+                    mangaExtensionsTabContent,
                     migrateAnimeSourceTab(),
                     migrateMangaSourceTab(),
                 )
             // SY <--
+        }
+
+        val animeExtensionsTabIndex = remember(tabs, animeExtensionsTabContent) {
+            tabs.indexOf(animeExtensionsTabContent)
+        }
+        val mangaExtensionsTabIndex = remember(tabs, mangaExtensionsTabContent) {
+            tabs.indexOf(mangaExtensionsTabContent)
         }
 
         val state = rememberPagerState { tabs.size }
@@ -152,11 +167,16 @@ data object BrowseTab : Tab {
             // KMK <--
             scrollable = true,
         )
-        LaunchedEffect(hideFeedTab, feedTabInFront) {
-            val tabOffset = if (hideFeedTab) 0 else 1
-            switchToTabNumberChannel.receiveAsFlow()
-                .collectLatest { tab ->
-                    state.scrollToPage(tab + tabOffset)
+        LaunchedEffect(animeExtensionsTabIndex, mangaExtensionsTabIndex) {
+            switchToExtensionTabChannel.receiveAsFlow()
+                .collectLatest { target ->
+                    val tabIndex = when (target) {
+                        ExtensionTabTarget.ANIME -> animeExtensionsTabIndex
+                        ExtensionTabTarget.MANGA -> mangaExtensionsTabIndex
+                    }
+                    if (tabIndex >= 0) {
+                        state.scrollToPage(tabIndex)
+                    }
                 }
         }
 


### PR DESCRIPTION
A (Possible) fix for issue #390. I am not an Android dev, so I'm not sure what the best way to test this on a computer is, but it should be fine. The new index numbers match what the Browse tab list should have (Assuming the index starts at 0)
