### PR TITLE
feat: add configurable FlareSolverr timeout and improve WebView header handling

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -250,6 +250,7 @@ object SettingsAdvancedScreen : SearchableSettings {
 
         // TLMR -->
         val flareSolverrUrlPref = networkPreferences.flareSolverrUrl()
+        val flareSolverrTimeoutPref = networkPreferences.flareSolverrTimeout()
         val enableFlareSolverrPref = networkPreferences.enableFlareSolverr()
         val enableFlareSolverr by enableFlareSolverrPref.collectAsState()
         // <-- TLMR
@@ -390,13 +391,31 @@ object SettingsAdvancedScreen : SearchableSettings {
                     enabled = enableFlareSolverr,
                     subtitle = stringResource(TLMR.strings.pref_flare_solverr_url_summary),
                 ),
+                Preference.PreferenceItem.ListPreference(
+                    preference = flareSolverrTimeoutPref,
+                    entries = persistentMapOf(
+                        10000 to "10s",
+                        30000 to "30s",
+                        60000 to "1m",
+                        90000 to "1.5m",
+                        120000 to "2m",
+                    ),
+                    title = stringResource(TLMR.strings.pref_flare_solverr_timeout),
+                    enabled = enableFlareSolverr,
+                    subtitle = stringResource(TLMR.strings.pref_flare_solverr_timeout_summary),
+                ),
                 Preference.PreferenceItem.TextPreference(
                     title = stringResource(TLMR.strings.pref_test_flare_solverr_and_update_user_agent),
                     enabled = enableFlareSolverr,
                     subtitle = stringResource(TLMR.strings.pref_test_flare_solverr_and_update_user_agent_summary),
                     onClick = {
                         scope.launch {
-                            testFlareSolverrAndUpdateUserAgent(flareSolverrUrlPref, userAgentPref, context)
+                            testFlareSolverrAndUpdateUserAgent(
+                                flareSolverrUrlPref,
+                                flareSolverrTimeoutPref,
+                                userAgentPref,
+                                context,
+                            )
                         }
                     },
                 ),
@@ -667,12 +686,18 @@ object SettingsAdvancedScreen : SearchableSettings {
     // TLMR -->
     private suspend fun testFlareSolverrAndUpdateUserAgent(
         flareSolverrUrlPref: BasePreference<String>,
+        flareSolverrTimeoutPref: BasePreference<Int>,
         userAgentPref: BasePreference<String>,
         context: android.content.Context,
     ) {
         val json: Json by injectLazy()
         val jsonMediaType = "application/json".toMediaType()
-        val client = OkHttpClient.Builder().build()
+        val timeout = flareSolverrTimeoutPref.get() + 10000
+        val client = OkHttpClient.Builder()
+            .readTimeout(timeout.toLong(), java.util.concurrent.TimeUnit.MILLISECONDS)
+            .writeTimeout(timeout.toLong(), java.util.concurrent.TimeUnit.MILLISECONDS)
+            .connectTimeout(timeout.toLong(), java.util.concurrent.TimeUnit.MILLISECONDS)
+            .build()
 
         try {
             withContext(Dispatchers.IO) {
@@ -687,7 +712,7 @@ object SettingsAdvancedScreen : SearchableSettings {
                                     "request.get",
                                     "https://www.google.com/",
                                     returnOnlyCookies = true,
-                                    maxTimeout = 60000,
+                                    maxTimeout = flareSolverrTimeoutPref.get(),
                                 ),
                             ).toRequestBody(jsonMediaType),
                         ),

--- a/app/src/main/java/eu/kanade/presentation/webview/WebViewScreenContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/webview/WebViewScreenContent.kt
@@ -80,10 +80,19 @@ fun WebViewScreenContent(
     headers: Map<String, String> = emptyMap(),
     onUrlChange: (String) -> Unit = {},
 ) {
+    val filteredHeaders = remember(headers) {
+        headers.filter { (key, value) ->
+            val name = key.lowercase(java.util.Locale.ENGLISH)
+            if (name in listOf("user-agent", "content-length", "host", "trailer", "te", "upgrade", "cookie2", "keep-alive", "transfer-encoding", "set-cookie") || name.startsWith("proxy-")) return@filter false
+            if (name == "connection" && value.lowercase(java.util.Locale.ENGLISH) == "upgrade") return@filter false
+            true
+        }.mapKeys { it.key.lowercase(java.util.Locale.ENGLISH) }
+    }
+
     val windowStack = remember {
         mutableStateStackOf(
             WebViewWindow(
-                WebContent.Url(url = url, additionalHttpHeaders = headers),
+                WebContent.Url(url = url, additionalHttpHeaders = filteredHeaders),
             ),
         )
     }
@@ -150,18 +159,28 @@ fun WebViewScreenContent(
                 request: WebResourceRequest?,
             ): Boolean {
                 request?.let {
+                    val url = it.url.toString()
                     // Don't attempt to open blobs as webpages
-                    if (it.url.toString().startsWith("blob:http")) {
+                    if (url.startsWith("blob:http")) {
                         return false
                     }
 
                     // Ignore intents urls
-                    if (it.url.toString().startsWith("intent://")) {
+                    if (url.startsWith("intent://")) {
                         return true
                     }
 
                     // Continue with request, but with custom headers
-                    view?.loadUrl(it.url.toString(), headers)
+                    val requestHeaders = it.requestHeaders ?: emptyMap()
+                    val requestHeaderKeys = requestHeaders.keys.map { it.lowercase(java.util.Locale.ENGLISH) }
+                    val currentUrl = view?.url
+                    if (it.isForMainFrame &&
+                        !url.equals(currentUrl, ignoreCase = true) &&
+                        !requestHeaderKeys.containsAll(filteredHeaders.keys)
+                    ) {
+                        view?.loadUrl(url, filteredHeaders)
+                        return true
+                    }
                 }
                 return super.shouldOverrideUrlLoading(view, request)
             }
@@ -332,7 +351,7 @@ fun WebViewScreenContent(
                         WebView.setWebContentsDebuggingEnabled(true)
                     }
 
-                    headers["user-agent"]?.let {
+                    headers.entries.find { it.key.lowercase(java.util.Locale.ENGLISH) == "user-agent" }?.value?.let {
                         webView.settings.userAgentString = it
                     }
                 },

--- a/app/src/main/java/eu/kanade/presentation/webview/WebViewScreenContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/webview/WebViewScreenContent.kt
@@ -83,7 +83,19 @@ fun WebViewScreenContent(
     val filteredHeaders = remember(headers) {
         headers.filter { (key, value) ->
             val name = key.lowercase(java.util.Locale.ENGLISH)
-            if (name in listOf("user-agent", "content-length", "host", "trailer", "te", "upgrade", "cookie2", "keep-alive", "transfer-encoding", "set-cookie") || name.startsWith("proxy-")) return@filter false
+            val excludedHeaders = listOf(
+                "user-agent",
+                "content-length",
+                "host",
+                "trailer",
+                "te",
+                "upgrade",
+                "cookie2",
+                "keep-alive",
+                "transfer-encoding",
+                "set-cookie",
+            )
+            if (name in excludedHeaders || name.startsWith("proxy-")) return@filter false
             if (name == "connection" && value.lowercase(java.util.Locale.ENGLISH) == "upgrade") return@filter false
             true
         }.mapKeys { it.key.lowercase(java.util.Locale.ENGLISH) }
@@ -172,7 +184,9 @@ fun WebViewScreenContent(
 
                     // Continue with request, but with custom headers
                     val requestHeaders = it.requestHeaders ?: emptyMap()
-                    val requestHeaderKeys = requestHeaders.keys.map { it.lowercase(java.util.Locale.ENGLISH) }
+                    val requestHeaderKeys = requestHeaders.keys.map {
+                        it.lowercase(java.util.Locale.ENGLISH)
+                    }
                     val currentUrl = view?.url
                     if (it.isForMainFrame &&
                         !url.equals(currentUrl, ignoreCase = true) &&
@@ -351,7 +365,9 @@ fun WebViewScreenContent(
                         WebView.setWebContentsDebuggingEnabled(true)
                     }
 
-                    headers.entries.find { it.key.lowercase(java.util.Locale.ENGLISH) == "user-agent" }?.value?.let {
+                    headers.entries.find {
+                        it.key.lowercase(java.util.Locale.ENGLISH) == "user-agent"
+                    }?.value?.let {
                         webView.settings.userAgentString = it
                     }
                 },

--- a/core/common/src/main/java/eu/kanade/tachiyomi/network/NetworkPreferences.kt
+++ b/core/common/src/main/java/eu/kanade/tachiyomi/network/NetworkPreferences.kt
@@ -14,6 +14,8 @@ class NetworkPreferences(
     val enableFlareSolverr: Preference<Boolean> = preferenceStore.getBoolean("enable_flare_solverr", false)
 
     val flareSolverrUrl: Preference<String> = preferenceStore.getString("flare_solverr_url", "http://localhost:8191/v1")
+
+    val flareSolverrTimeout: Preference<Int> = preferenceStore.getInt("flare_solverr_timeout", 30000)
     // <-- TLMR
 
     val dohProvider: Preference<Int> = preferenceStore.getInt("doh_provider", -1)
@@ -32,6 +34,8 @@ class NetworkPreferences(
     fun enableFlareSolverr() = enableFlareSolverr
 
     fun flareSolverrUrl() = flareSolverrUrl
+
+    fun flareSolverrTimeout() = flareSolverrTimeout
 
     fun dohProvider() = dohProvider
 

--- a/core/common/src/main/java/eu/kanade/tachiyomi/network/interceptor/FlareSolverrInterceptor.kt
+++ b/core/common/src/main/java/eu/kanade/tachiyomi/network/interceptor/FlareSolverrInterceptor.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import logcat.LogPriority
 import logcat.logcat
@@ -65,7 +64,8 @@ class FlareSolverrInterceptor(private val preferences: NetworkPreferences) : Int
         private val json: Json by injectLazy()
         private val jsonMediaType = "application/json".toMediaType()
         private val networkPreferences: NetworkPreferences by injectLazy()
-        private val flareSolverrUrl = networkPreferences.flareSolverrUrl.get()
+        private val flareSolverrUrl get() = networkPreferences.flareSolverrUrl().get()
+        private val flareSolverrTimeout get() = networkPreferences.flareSolverrTimeout().get()
         private val mutex = Mutex()
 
         @Serializable
@@ -133,24 +133,38 @@ class FlareSolverrInterceptor(private val preferences: NetworkPreferences) : Int
             val flareSolverResponse =
                 with(json) {
                     mutex.withLock {
-                        network.client.newCall(
-                            POST(
-                                url = flareSolverrUrl,
-                                body =
-                                Json.encodeToString(
-                                    FlareSolverRequest(
-                                        "request.get",
-                                        originalRequest.url.toString(),
-                                        cookies =
-                                        network.cookieJar.get(originalRequest.url).map {
-                                            FlareSolverCookie(it.name, it.value)
-                                        },
-                                        returnOnlyCookies = true,
-                                        maxTimeout = 30000,
-                                    ),
-                                ).toRequestBody(jsonMediaType),
-                            ),
-                        ).awaitSuccess().parseAs<FlareSolverResponse>()
+                        network.client.newBuilder()
+                            .readTimeout(
+                                (flareSolverrTimeout + 10000).toLong(),
+                                java.util.concurrent.TimeUnit.MILLISECONDS,
+                            )
+                            .writeTimeout(
+                                (flareSolverrTimeout + 10000).toLong(),
+                                java.util.concurrent.TimeUnit.MILLISECONDS,
+                            )
+                            .connectTimeout(
+                                (flareSolverrTimeout + 10000).toLong(),
+                                java.util.concurrent.TimeUnit.MILLISECONDS,
+                            )
+                            .build()
+                            .newCall(
+                                POST(
+                                    url = flareSolverrUrl,
+                                    body =
+                                    Json.encodeToString(
+                                        FlareSolverRequest(
+                                            "request.get",
+                                            originalRequest.url.toString(),
+                                            cookies =
+                                            network.cookieJar.get(originalRequest.url).map {
+                                                FlareSolverCookie(it.name, it.value)
+                                            },
+                                            returnOnlyCookies = true,
+                                            maxTimeout = flareSolverrTimeout,
+                                        ),
+                                    ).toRequestBody(jsonMediaType),
+                                ),
+                            ).awaitSuccess().parseAs<FlareSolverResponse>()
                     }
                 }
 

--- a/i18n-tail/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-tail/src/commonMain/moko-resources/base/strings.xml
@@ -201,6 +201,8 @@
     <string name="pref_enable_flare_solverr_summary">Use FlareSolverr to bypass Cloudflare\'s anti-bot protection</string>
     <string name="pref_flare_solverr_url">FlareSolverr URL</string>
     <string name="pref_flare_solverr_url_summary">URL of the FlareSolverr instance to use for example http://192.168.1.202:8191/v1</string>
+    <string name="pref_flare_solverr_timeout">FlareSolverr Timeout</string>
+    <string name="pref_flare_solverr_timeout_summary">Maximum time to wait for a solution</string>
     <string name="pref_test_flare_solverr_and_update_user_agent">Test FlareSolverr and update user agent</string>
     <string name="pref_test_flare_solverr_and_update_user_agent_summary">Test FlareSolverr to update the user agent. Only required once; then toggle as needed.</string>
 

--- a/i18n-tail/src/commonMain/moko-resources/es/strings.xml
+++ b/i18n-tail/src/commonMain/moko-resources/es/strings.xml
@@ -153,6 +153,8 @@
   <string name="pref_enable_flare_solverr_summary">Utiliza FlareSolverr para superar la protección antibots de Cloudflare</string>
   <string name="pref_flare_solverr_url">URL de FlareSolverr</string>
   <string name="pref_flare_solverr_url_summary">URL de la instancia de FlareSolverr a utilizar, por ejemplo: http://192.168.1.202:8191/v1</string>
+  <string name="pref_flare_solverr_timeout">Tiempo de espera de FlareSolverr</string>
+  <string name="pref_flare_solverr_timeout_summary">Tiempo máximo a esperar por una solución</string>
   <string name="pref_test_flare_solverr_and_update_user_agent">Probar FlareSolverr y actualizar el agente de usuario</string>
   <string name="pref_test_flare_solverr_and_update_user_agent_summary">Pruebe FlareSolverr para actualizar el agente de usuario. Solo es necesario una vez; luego cambie según sea necesario.</string>
   <string-array name="title_cast_quality">


### PR DESCRIPTION
- Add FlareSolverr timeout preference to advanced settings with selectable values
- Pass configured timeout to FlareSolverr requests and test function
- Update strings for new timeout option (EN/ES)
- Filter and normalize headers in WebView to avoid sending restricted headers
- Fix WebView to use filtered headers on navigation and user agent assignment
- Close #392 
