### PR TITLE
Update BrowseTab.kt

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseTab.kt
@@ -158,10 +158,10 @@ data object BrowseTab : Tab {
             titleRes = MR.strings.browse,
             tabs = tabs,
             state = state,
-            mangaSearchQuery = animeExtensionsState.searchQuery,
-            onChangeMangaSearchQuery = animeExtensionsScreenModel::search,
-            animeSearchQuery = mangaExtensionsState.searchQuery,
-            onChangeAnimeSearchQuery = mangaExtensionsScreenModel::search,
+            mangaSearchQuery = mangaExtensionsState.searchQuery,
+            onChangeMangaSearchQuery = mangaExtensionsScreenModel::search,
+            animeSearchQuery = animeExtensionsState.searchQuery,
+            onChangeAnimeSearchQuery = animeExtensionsScreenModel::search,
             // KMK -->
             feedScreenModel = feedScreenModel,
             // KMK <--


### PR DESCRIPTION
It's has typeo and i fix it. 
Problem --> if you search manga extension it's show us anime extension and if you search anime extension it's show us Manga extension  Fix --> Update BrowseTab.kt
Location --> app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseTab.kt

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
