### PR TITLE
fix: enable search in history tabs

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoriesTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoriesTab.kt
@@ -89,6 +89,8 @@ data object HistoriesTab : Tab {
             onChangeMangaSearchQuery = mangaHistoryScreenModel::search,
             animeSearchQuery = animeSearchQuery,
             onChangeAnimeSearchQuery = animeHistoryScreenModel::search,
+            animeExtensionsTabIndex = TAB_ANIME,
+            mangaExtensionsTabIndex = TAB_MANGA,
             // KMK -->
             feedScreenModel = feedScreenModel,
             // KMK <--


### PR DESCRIPTION
Pass anime and manga tab indices to TabbedScreen in HistoriesTab to correctly bind the search query and search query listener.

Close #430 
