### PR TITLE
fix(torrent): restore binary compatibility for extension torrent utils API

### DIFF
--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/torrentutils/TorrentUtils.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/torrentutils/TorrentUtils.kt
@@ -5,18 +5,19 @@ import aniyomi.core.common.torrent.TorrentServerApi
 import eu.kanade.tachiyomi.torrentutils.model.DeadTorrentException
 import eu.kanade.tachiyomi.torrentutils.model.TorrentFile
 import eu.kanade.tachiyomi.torrentutils.model.TorrentInfo
+import kotlinx.coroutines.runBlocking
 import uy.kohesive.injekt.injectLazy
 import java.net.SocketTimeoutException
 
 object TorrentUtils {
     private val torrentServerApi: TorrentServerApi by injectLazy()
 
-    suspend fun getTorrentInfo(
+    fun getTorrentInfo(
         url: String,
         title: String,
     ): TorrentInfo {
         try {
-            val torrent = torrentServerApi.addTorrent(url, title, "", "", false)
+            val torrent = runBlocking { torrentServerApi.addTorrent(url, title, "", "", false) }
             return TorrentInfo(
                 torrent.title,
                 torrent.fileStats?.map { file ->


### PR DESCRIPTION
Revert TorrentUtils.getTorrentInfo from suspend to a regular function to fix NoSuchMethodError in torrent extensions.

The Aniyomi merge (#419) changed getTorrentInfo to suspend, which alters its JVM signature by adding a Continuation parameter. Extensions compiled against the old API could not find the method at runtime.

Wraps the internal suspend addTorrent() call with runBlocking to bridge the coroutine boundary while preserving the original method signature.

Closes #438