### PR TITLE
fix(extensions): resolve 1.6+ extension loading and chapter memo persistence

### DIFF
--- a/app/src/main/java/eu/kanade/domain/entries/manga/interactor/UpdateManga.kt
+++ b/app/src/main/java/eu/kanade/domain/entries/manga/interactor/UpdateManga.kt
@@ -83,6 +83,7 @@ class UpdateManga(
                 status = remoteManga.status.toLong(),
                 updateStrategy = remoteManga.update_strategy,
                 initialized = true,
+                memo = remoteManga.memo,
             ),
         )
     }

--- a/app/src/main/java/eu/kanade/domain/entries/manga/model/Manga.kt
+++ b/app/src/main/java/eu/kanade/domain/entries/manga/model/Manga.kt
@@ -45,6 +45,7 @@ fun Manga.toSManga(): SManga = SManga.create().also {
     it.status = status.toInt()
     it.thumbnail_url = thumbnailUrl
     it.initialized = initialized
+    it.memo = memo
 }
 
 fun Manga.copyFrom(other: SManga): Manga {
@@ -72,6 +73,7 @@ fun Manga.copyFrom(other: SManga): Manga {
         // SY <--
         updateStrategy = other.update_strategy,
         initialized = other.initialized && initialized,
+        memo = other.memo,
     )
 }
 
@@ -90,6 +92,7 @@ fun SManga.toDomainManga(sourceId: Long): Manga {
         updateStrategy = update_strategy,
         initialized = initialized,
         source = sourceId,
+        memo = memo,
     )
 }
 

--- a/app/src/main/java/eu/kanade/domain/items/chapter/model/Chapter.kt
+++ b/app/src/main/java/eu/kanade/domain/items/chapter/model/Chapter.kt
@@ -13,6 +13,7 @@ fun Chapter.toSChapter(): SChapter {
         it.date_upload = dateUpload
         it.chapter_number = chapterNumber.toFloat()
         it.scanlator = scanlator
+        it.memo = memo
     }
 }
 
@@ -23,6 +24,7 @@ fun Chapter.copyFromSChapter(sChapter: SChapter): Chapter {
         dateUpload = sChapter.date_upload,
         chapterNumber = sChapter.chapter_number.toDouble(),
         scanlator = sChapter.scanlator?.ifBlank { null }?.trim(),
+        memo = sChapter.memo ?: this.memo,
     )
 }
 
@@ -41,4 +43,5 @@ fun Chapter.toDbChapter(): DbChapter = ChapterImpl().also {
     it.chapter_number = chapterNumber.toFloat()
     it.source_order = sourceOrder.toInt()
     it.last_modified = lastModifiedAt
+    it.memo = memo
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/manga/util/MangaExtensionLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/manga/util/MangaExtensionLoader.kt
@@ -14,6 +14,7 @@ import eu.kanade.tachiyomi.extension.manga.model.MangaExtension
 import eu.kanade.tachiyomi.extension.manga.model.MangaLoadResult
 import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.source.MangaSource
+import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.SourceFactory
 import eu.kanade.tachiyomi.util.lang.Hash
 import eu.kanade.tachiyomi.util.storage.copyAndSetReadOnlyTo
@@ -66,7 +67,7 @@ internal object MangaExtensionLoader {
     private const val METADATA_EXTENSION_LIB = "tachiyomix.extensionLib"
     private const val METADATA_CONTENT_WARNING = "tachiyomix.contentWarning"
 
-    private val SUPPORTED_LIB_VERSIONS = listOf(1.4, 1.5, 1.6)
+    private val SUPPORTED_LIB_VERSIONS = listOf(1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 14.0, 15.0, 16.0, 17.0)
 
     @Suppress("DEPRECATION")
     private val PACKAGE_FLAGS = PackageManager.GET_CONFIGURATIONS or
@@ -342,7 +343,11 @@ internal object MangaExtensionLoader {
             return MangaLoadResult.Error
         }
 
-        val sources = appInfo.metaData.getString(METADATA_SOURCE_CLASS)!!
+        val sourceClassString = appInfo.metaData?.getString(METADATA_SOURCE_FACTORY)
+            ?: appInfo.metaData?.getString(METADATA_SOURCE_CLASS)
+            ?: return MangaLoadResult.Error
+
+        val sources = sourceClassString
             .split(";")
             .map {
                 val sourceClass = it.trim()
@@ -352,37 +357,19 @@ internal object MangaExtensionLoader {
                     sourceClass
                 }
             }
-            .flatMap {
+            .flatMap { className ->
                 try {
-                    when (val obj = Class.forName(it, false, classLoader).getDeclaredConstructor().newInstance()) {
-                        is MangaSource -> listOf(obj)
-                        is SourceFactory -> obj.createSources()
-                        else -> throw Exception("Unknown source class type: ${obj.javaClass}")
-                    }
+                    loadSourceClass(className, classLoader)
                 } catch (e: LinkageError) {
                     try {
                         val fallBackClassLoader = PathClassLoader(appInfo.sourceDir, null, context.classLoader)
-                        when (
-                            val obj = Class.forName(
-                                it,
-                                false,
-                                fallBackClassLoader,
-                            ).getDeclaredConstructor().newInstance()
-                        ) {
-                            is MangaSource -> {
-                                listOf(obj)
-                            }
-
-                            is SourceFactory -> obj.createSources()
-
-                            else -> throw Exception("Unknown source class type: ${obj.javaClass}")
-                        }
+                        loadSourceClass(className, fallBackClassLoader)
                     } catch (e: Throwable) {
-                        logcat(LogPriority.ERROR, e) { "Extension load error: $extName ($it)" }
+                        logcat(LogPriority.ERROR, e) { "Extension load error: $extName ($className)" }
                         return MangaLoadResult.Error
                     }
                 } catch (e: Throwable) {
-                    logcat(LogPriority.ERROR, e) { "Extension load error: $extName ($it)" }
+                    logcat(LogPriority.ERROR, e) { "Extension load error: $extName ($className)" }
                     return MangaLoadResult.Error
                 }
             }
@@ -489,6 +476,41 @@ internal object MangaExtensionLoader {
         }
         if (publicSourceDir == null) {
             publicSourceDir = apkPath
+        }
+    }
+
+    private fun loadSourceClass(className: String, classLoader: ClassLoader): List<MangaSource> {
+        val pkg = className.substringBeforeLast('.')
+        var clazz = try {
+            Class.forName(className, false, classLoader)
+        } catch (e: ClassNotFoundException) {
+            try {
+                Class.forName("$pkg.ExtensionGenerated", false, classLoader)
+            } catch (_: ClassNotFoundException) {
+                Class.forName("${className}Generated", false, classLoader)
+            }
+        }
+        if (java.lang.reflect.Modifier.isAbstract(clazz.modifiers)) {
+            clazz = try {
+                Class.forName("$pkg.ExtensionGenerated", false, classLoader)
+            } catch (_: Exception) {
+                try {
+                    Class.forName("${className}Generated", false, classLoader)
+                } catch (_: Exception) {
+                    try {
+                        Class.forName("${className}Impl", false, classLoader)
+                    } catch (_: Exception) {
+                        clazz
+                    }
+                }
+            }
+        }
+        val obj = clazz.getDeclaredConstructor().newInstance()
+        return when (obj) {
+            is MangaSource -> listOf(obj)
+            is Source -> listOf(obj as MangaSource)
+            is SourceFactory -> obj.createSources().filterIsInstance<MangaSource>()
+            else -> throw Exception("Unknown source class type: ${obj?.javaClass}")
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/MangaScreenModel.kt
@@ -28,6 +28,7 @@ import eu.kanade.domain.entries.manga.model.toSManga
 import eu.kanade.domain.items.chapter.interactor.GetAvailableScanlators
 import eu.kanade.domain.items.chapter.interactor.SetReadStatus
 import eu.kanade.domain.items.chapter.interactor.SyncChaptersWithSource
+import eu.kanade.domain.items.chapter.model.toSChapter
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.domain.track.manga.interactor.AddMangaTracks
 import eu.kanade.domain.track.manga.interactor.RefreshMangaTracks
@@ -269,11 +270,9 @@ class MangaScreenModel(
 
             // Fetch info-chapters when needed
             if (screenModelScope.isActive) {
-                val fetchFromSourceTasks = listOf(
-                    async { if (needRefreshInfo) fetchMangaFromSource() },
-                    async { if (needRefreshChapter) fetchChaptersFromSource() },
-                )
-                fetchFromSourceTasks.awaitAll()
+                if (needRefreshInfo || needRefreshChapter) {
+                    fetchMangaAndChaptersFromSource()
+                }
             }
 
             // Initial loading finished
@@ -289,11 +288,7 @@ class MangaScreenModel(
     fun fetchAllFromSource(manualFetch: Boolean = true) {
         screenModelScope.launch {
             updateSuccessState { it.copy(isRefreshingData = true) }
-            val fetchFromSourceTasks = listOf(
-                async { fetchMangaFromSource(manualFetch) },
-                async { fetchChaptersFromSource(manualFetch) },
-            )
-            fetchFromSourceTasks.awaitAll()
+            fetchMangaAndChaptersFromSource(manualFetch)
             updateSuccessState { it.copy(isRefreshingData = false) }
         }
     }
@@ -321,6 +316,7 @@ class MangaScreenModel(
         setRelatedMangasFetchedStatus(false)
 
         fun exceptionHandler(e: Throwable) {
+            if (e is UnsupportedOperationException) return
             logcat(LogPriority.ERROR, e)
             val message = with(context) { e.formattedMessage }
 
@@ -351,6 +347,8 @@ class MangaScreenModel(
                     }
                 }
             }
+        } catch (e: UnsupportedOperationException) {
+            // Ignore for sources that don't implement related manga
         } catch (e: Exception) {
             exceptionHandler(e)
         } finally {
@@ -377,15 +375,70 @@ class MangaScreenModel(
     // Manga info - start
 
     /**
+     * Fetch manga information and chapters from source using getMangaUpdate.
+     */
+    private suspend fun fetchMangaAndChaptersFromSource(manualFetch: Boolean = false) {
+        val state = successState ?: return
+        val source = sourceManager.get(state.manga.source) ?: state.source
+        if (source is StubMangaSource) return
+        try {
+            withIOContext {
+                val currentChapters = state.chapters.map { it.chapter.toSChapter() }
+                val mangaUpdate = source.getMangaUpdate(
+                    state.manga.toSManga(),
+                    currentChapters,
+                    fetchDetails = true,
+                    fetchChapters = true,
+                )
+
+                updateManga.awaitUpdateFromSource(state.manga, mangaUpdate.manga, manualFetch)
+
+                val newChapters = syncChaptersWithSource.await(
+                    mangaUpdate.chapters,
+                    state.manga,
+                    source,
+                    manualFetch,
+                )
+
+                if (manualFetch) {
+                    downloadNewChapters(newChapters)
+                }
+            }
+        } catch (e: Throwable) {
+            if (e is HttpException && e.code == 103) return
+            val message = if (e is NoChaptersException || e is UnsupportedOperationException) {
+                context.stringResource(MR.strings.no_chapters_error)
+            } else {
+                logcat(LogPriority.ERROR, e)
+                with(context) { e.formattedMessage }
+            }
+
+            screenModelScope.launch {
+                snackbarHostState.showSnackbar(message = message)
+            }
+        }
+    }
+
+    /**
      * Fetch manga information from source.
      */
     private suspend fun fetchMangaFromSource(manualFetch: Boolean = false) {
         val state = successState ?: return
+        val source = sourceManager.get(state.manga.source) ?: state.source
+        if (source is StubMangaSource) return
         try {
             withIOContext {
-                val networkManga = state.source.getMangaDetails(state.manga.toSManga())
-                updateManga.awaitUpdateFromSource(state.manga, networkManga, manualFetch)
+                val currentChapters = state.chapters.map { it.chapter.toSChapter() }
+                val mangaUpdate = source.getMangaUpdate(
+                    state.manga.toSManga(),
+                    currentChapters,
+                    fetchDetails = true,
+                    fetchChapters = false,
+                )
+                updateManga.awaitUpdateFromSource(state.manga, mangaUpdate.manga, manualFetch)
             }
+        } catch (e: UnsupportedOperationException) {
+            // Ignore if source does not implement/support mangaDetailsRequest
         } catch (e: Throwable) {
             // Ignore early hints "errors" that aren't handled by OkHttp
             if (e is HttpException && e.code == 103) return
@@ -744,14 +797,22 @@ class MangaScreenModel(
      */
     private suspend fun fetchChaptersFromSource(manualFetch: Boolean = false) {
         val state = successState ?: return
+        val source = sourceManager.get(state.manga.source) ?: state.source
+        if (source is StubMangaSource) return
         try {
             withIOContext {
-                val chapters = state.source.getChapterList(state.manga.toSManga())
+                val currentChapters = state.chapters.map { it.chapter.toSChapter() }
+                val mangaUpdate = source.getMangaUpdate(
+                    state.manga.toSManga(),
+                    currentChapters,
+                    fetchDetails = false,
+                    fetchChapters = true,
+                )
 
                 val newChapters = syncChaptersWithSource.await(
-                    chapters,
+                    mangaUpdate.chapters,
                     state.manga,
-                    state.source,
+                    source,
                     manualFetch,
                 )
 
@@ -760,7 +821,7 @@ class MangaScreenModel(
                 }
             }
         } catch (e: Throwable) {
-            val message = if (e is NoChaptersException) {
+            val message = if (e is NoChaptersException || e is UnsupportedOperationException) {
                 context.stringResource(MR.strings.no_chapters_error)
             } else {
                 logcat(LogPriority.ERROR, e)

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/ChildFirstPathClassLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/ChildFirstPathClassLoader.kt
@@ -29,6 +29,12 @@ class ChildFirstPathClassLoader(
             } catch (_: ClassNotFoundException) {}
         }
 
+        if (c == null && name != null && isParentFirstPackage(name)) {
+            try {
+                c = super.loadClass(name, resolve)
+            } catch (_: ClassNotFoundException) {}
+        }
+
         if (c == null) {
             c = try {
                 findClass(name)
@@ -42,6 +48,21 @@ class ChildFirstPathClassLoader(
         }
 
         return c
+    }
+
+    private fun isParentFirstPackage(name: String): Boolean {
+        return name.startsWith("eu.kanade.tachiyomi.source.") ||
+            name.startsWith("eu.kanade.tachiyomi.animesource.") ||
+            name.startsWith("eu.kanade.tachiyomi.network.") ||
+            name.startsWith("tachiyomi.") ||
+            name.startsWith("uy.kohesive.injekt.") ||
+            name.startsWith("keiyoushi.") ||
+            name.startsWith("rx.") ||
+            name.startsWith("okhttp3.") ||
+            name.startsWith("kotlin.") ||
+            name.startsWith("kotlinx.") ||
+            name.startsWith("android.") ||
+            name.startsWith("androidx.")
     }
 
     override fun getResource(name: String?): URL? {

--- a/domain/src/main/java/tachiyomi/domain/items/chapter/interactor/ShouldUpdateDbChapter.kt
+++ b/domain/src/main/java/tachiyomi/domain/items/chapter/interactor/ShouldUpdateDbChapter.kt
@@ -9,6 +9,7 @@ class ShouldUpdateDbChapter {
             dbChapter.name != sourceChapter.name ||
             dbChapter.dateUpload != sourceChapter.dateUpload ||
             dbChapter.chapterNumber != sourceChapter.chapterNumber ||
-            dbChapter.sourceOrder != sourceChapter.sourceOrder
+            dbChapter.sourceOrder != sourceChapter.sourceOrder ||
+            dbChapter.memo != sourceChapter.memo
     }
 }

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/CatalogueSource.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/CatalogueSource.kt
@@ -2,8 +2,11 @@ package eu.kanade.tachiyomi.source
 
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
@@ -22,7 +25,7 @@ interface CatalogueSource : MangaSource {
     /**
      * Whether the source has support for latest updates.
      */
-    val supportsLatest: Boolean
+    override val supportsLatest: Boolean
 
     /**
      * Get a page with a list of manga.
@@ -62,7 +65,8 @@ interface CatalogueSource : MangaSource {
     /**
      * Returns the list of filters for the source.
      */
-    fun getFilterList(): FilterList
+    override fun
+        getFilterList(): FilterList
 
     @Deprecated(
         "Use the non-RxJava API instead",
@@ -84,6 +88,18 @@ interface CatalogueSource : MangaSource {
     )
     fun fetchLatestUpdates(page: Int): Observable<MangasPage> =
         throw IllegalStateException("Not used")
+
+    @Suppress("DEPRECATION")
+    override suspend fun getMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate = supervisorScope {
+        val asyncManga = if (fetchDetails) async { getMangaDetails(manga) } else null
+        val asyncChapters = if (fetchChapters) async { getChapterList(manga) } else null
+        SMangaUpdate(asyncManga?.await() ?: manga, asyncChapters?.await() ?: chapters)
+    }
 
     // KMK -->
 

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/CatalogueSource.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/CatalogueSource.kt
@@ -65,8 +65,7 @@ interface CatalogueSource : MangaSource {
     /**
      * Returns the list of filters for the source.
      */
-    override fun
-        getFilterList(): FilterList
+    override fun getFilterList(): FilterList
 
     @Deprecated(
         "Use the non-RxJava API instead",

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/MangaSource.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/MangaSource.kt
@@ -3,25 +3,26 @@ package eu.kanade.tachiyomi.source
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.model.SMangaUpdate
 import eu.kanade.tachiyomi.util.awaitSingle
 import rx.Observable
 
 /**
  * A basic interface for creating a source. It could be an online source, a local source, etc.
  */
-interface MangaSource {
+interface MangaSource : Source {
 
     /**
      * ID for the source. Must be unique.
      */
-    val id: Long
+    override val id: Long
 
     /**
      * Name of the source.
      */
-    val name: String
+    override val name: String
 
-    val lang: String
+    override val lang: String
         get() = ""
 
     /**
@@ -81,6 +82,30 @@ interface MangaSource {
     )
     fun fetchPageList(chapter: SChapter): Observable<List<Page>> =
         throw IllegalStateException("Not used")
+
+    /**
+     * Fetches updated information for a manga.
+     *
+     * Depending on the provided flags or source availability, this may include
+     * updated manga metadata, available chapters, or both.
+     *
+     * @since tachiyomix 1.6
+     * @param manga The manga to fetch updates for.
+     * @param chapters Existing chapters of the manga
+     * @param fetchDetails Whether to fetch updated manga details.
+     * @param fetchChapters Whether to fetch available chapters.
+     */
+    @Suppress("DEPRECATION")
+    suspend fun getMangaUpdate(
+        manga: SManga,
+        chapters: List<SChapter>,
+        fetchDetails: Boolean,
+        fetchChapters: Boolean,
+    ): SMangaUpdate {
+        val updatedManga = if (fetchDetails) getMangaDetails(manga) else manga
+        val updatedChapters = if (fetchChapters) getChapterList(manga) else chapters
+        return SMangaUpdate(updatedManga, updatedChapters)
+    }
 
     // KMK -->
 

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/Source.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/Source.kt
@@ -1,0 +1,34 @@
+package eu.kanade.tachiyomi.source
+
+import eu.kanade.tachiyomi.source.model.FilterList
+
+/**
+ * A basic interface for creating a source. It could be an online source, a local source, etc.
+ * Maintained for backward compatibility with Tachiyomi / Mihon extensions.
+ */
+interface Source {
+
+    /**
+     * ID for the source. Must be unique.
+     */
+    val id: Long
+
+    /**
+     * Name of the source.
+     */
+    val name: String
+
+    val lang: String
+        get() = ""
+
+    /**
+     * Whether the source has support for latest updates.
+     */
+    val supportsLatest: Boolean
+        get() = true
+
+    /**
+     * Returns the list of filters for the source.
+     */
+    fun getFilterList(): FilterList = FilterList()
+}

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/SourceFactory.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/SourceFactory.kt
@@ -8,5 +8,5 @@ interface SourceFactory {
      * Create a new copy of the sources
      * @return The created sources
      */
-    fun createSources(): List<MangaSource>
+    fun createSources(): List<Source>
 }

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/model/SMangaUpdate.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/model/SMangaUpdate.kt
@@ -1,0 +1,4 @@
+package eu.kanade.tachiyomi.source.model
+
+@Suppress("UNUSED")
+class SMangaUpdate(val manga: SManga, val chapters: List<SChapter>)


### PR DESCRIPTION
 Restore Source base interface and update SourceFactory signature to List<Source>.
- Update ChildFirstPathClassLoader to delegate source, network, injekt, and keiyoushi packages parent-first.
- Prioritize METADATA_SOURCE_FACTORY in MangaExtensionLoader to instantiate KSP-generated ExtensionGenerated factories.
- Add getMangaUpdate support across MangaSource, CatalogueSource, and MangaScreenModel.
- Preserve manga and chapter memo metadata across domain mapping, SQLDelight persistence, and ReaderChapter conversions.
- Include memo comparison in ShouldUpdateDbChapter to ensure chapter metadata updates on refresh.

Close #444 